### PR TITLE
Accommodate 3 element tuple return from ssh execute command call

### DIFF
--- a/host_resource_checker.py
+++ b/host_resource_checker.py
@@ -24,11 +24,12 @@ class HostResourceChecker:
         try:
             # Command to retrieve host resource status
             command = "pvesh get /nodes/$(hostname)/status --output-format json"
-            output, error = self.ssh_client.execute_command(command)  # Properly unpack the tuple
+            output, error, exit_status = self.ssh_client.execute_command(command)  # Properly unpack the tuple
             
             # Debug logging
             self.logger.debug(f"Raw command output: {output}")
             self.logger.debug(f"Error output: {error}")
+            self.logger.debug(f"Exit status: {exit_status}")
             
             # Check for error output
             if error:


### PR DESCRIPTION
The ssh execute call returns a three element tuple  - output result, error message and exit status.