### PR TITLE
change command to extract CPU and RAM usage, and add blank option for smtp password to suppress login

### DIFF
--- a/autoscale.py
+++ b/autoscale.py
@@ -107,7 +107,8 @@ class NotificationManager:
 
             with smtplib.SMTP(smtp_config['host'], smtp_config['port']) as server:
                 server.starttls()
-                server.login(smtp_config['user'], smtp_config['password'])
+                if smtp_config['password']:
+                    server.login(smtp_config['user'], smtp_config['password'])
                 server.sendmail(smtp_config['user'], to_emails, msg.as_string())
             
             self.logger.info("Email notification sent successfully")


### PR DESCRIPTION
No CPU details in qm status vmid, so had to extract pid from a specific vmid and then use ps to get the cpu and ram usage.

To use my local mailserver I needed to set port 25 and supress the login, so checking for a blank password and skipping the smtp login.