### PR TITLE
ci: add GitHub Actions workflow (pytest matrix + shellcheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: pytest -q
+
+  shellcheck:
+    name: shellcheck install.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck (warnings and errors)
+        run: shellcheck -S warning install.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Proxmox VM Autoscale
+[![CI](https://github.com/fabriziosalmi/proxmox-vm-autoscale/actions/workflows/ci.yml/badge.svg)](https://github.com/fabriziosalmi/proxmox-vm-autoscale/actions/workflows/ci.yml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ffabriziosalmi%2Fproxmox-vm-autoscale.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ffabriziosalmi%2Fproxmox-vm-autoscale?ref=badge_shield)
 
 ## Overview


### PR DESCRIPTION
## What
The repo ships a `tests/` suite (**94 tests**) and a `curl | bash` `install.sh` but had **no CI** — nothing gated changes. This adds one.

## Adds
- `.github/workflows/ci.yml`:
  - **test** job: `pytest` on Python **3.9, 3.10, 3.11, 3.12**
  - **shellcheck** job: `shellcheck -S warning install.sh`
- CI status badge in the README.

## Verification (local, before pushing)
- `pip install -r requirements.txt pytest && pytest -q` → **94 passed** in a clean venv.
- `shellcheck -S warning install.sh` → clean (exit 0). (Default severity only flags 2 `SC2181` *style* nits, intentionally not gated.)
- No 3.10+ syntax in sources (`match` occurrences are a regex variable, not the statement); `py_compile` OK → safe across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)