### PR TITLE
docs: VitePress documentation site deployed to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,71 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+# Allow GITHUB_TOKEN to deploy to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; do not cancel a run that is mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # lastUpdated timestamps come from git history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run docs:build
+
+      - name: Verify generated artefacts
+        run: |
+          set -euo pipefail
+          out=docs/.vitepress/dist
+          for f in index.html sitemap.xml robots.txt llms.txt \
+                   .well-known/security.txt favicon.svg; do
+            test -s "$out/$f" || { echo "missing or empty: $f"; exit 1; }
+          done
+          grep -q 'application/ld+json' "$out/index.html" \
+            || { echo 'JSON-LD missing from index.html'; exit 1; }
+          grep -q 'rel="canonical"' "$out/index.html" \
+            || { echo 'canonical link missing from index.html'; exit 1; }
+          echo "artefact check passed"
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ Thumbs.db
 # Logs and config
 *.log
 config.local.yaml
+
+# Node / VitePress docs
+node_modules/
+docs/.vitepress/dist/
+docs/.vitepress/cache/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![CI](https://github.com/fabriziosalmi/proxmox-vm-autoscale/actions/workflows/ci.yml/badge.svg)](https://github.com/fabriziosalmi/proxmox-vm-autoscale/actions/workflows/ci.yml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ffabriziosalmi%2Fproxmox-vm-autoscale.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ffabriziosalmi%2Fproxmox-vm-autoscale?ref=badge_shield)
 
+📖 **[Full documentation](https://fabriziosalmi.github.io/proxmox-vm-autoscale/)** — installation, configuration reference, troubleshooting, security model and known limitations.
+
 ## Overview
 **Proxmox VM Autoscale** is a service that automatically adjusts virtual machine (VM) resources (CPU cores and RAM) on Proxmox Virtual Environment (VE) based on real-time metrics and user-defined thresholds.
 
@@ -21,6 +23,12 @@ The service connects to Proxmox hosts over SSH and runs as a **systemd** service
 - [Architecture](ARCHITECTURE.md)
 - [Security](SECURITY.md)
 - [License](#license)
+
+Longer-form guides live on the documentation site: [how scaling decisions are
+made](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/how-it-works.html),
+[configuration reference](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/configuration.html),
+[known limitations](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/limitations.html)
+and the [threat model](https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/).
 
 > [!IMPORTANT]
 > To enable scaling of VM resources, make sure NUMA and hotplug features are enabled:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,246 @@
+import { defineConfig, type HeadConfig } from 'vitepress'
+
+const BASE = '/proxmox-vm-autoscale/'
+const ORIGIN = 'https://fabriziosalmi.github.io'
+const SITE_URL = ORIGIN + BASE
+const REPO = 'https://github.com/fabriziosalmi/proxmox-vm-autoscale'
+const OG_IMAGE =
+  'https://repository-images.githubusercontent.com/864497613/5d9ba1ce-1327-4f6a-a1ed-9a75a2382609'
+
+const DESCRIPTION =
+  'Threshold-based CPU and RAM autoscaling for Proxmox VE virtual machines. ' +
+  'A systemd service that drives qm over SSH, with hotplug support, host safety ' +
+  'limits and Gotify/SMTP notifications.'
+
+/** Absolute URL for a page path emitted by VitePress (e.g. "guide/index.md"). */
+function canonicalFor(relativePath: string): string {
+  const path = relativePath
+    .replace(/index\.md$/, '')
+    .replace(/\.md$/, '.html')
+  return SITE_URL + path
+}
+
+/**
+ * Structured data describing the project. Emitted once, on every page, as a
+ * single @graph so crawlers and answer engines can resolve the relationships
+ * between the site, the software and its author without guessing.
+ */
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': SITE_URL + '#website',
+      url: SITE_URL,
+      name: 'Proxmox VM Autoscale',
+      description: DESCRIPTION,
+      inLanguage: 'en',
+      publisher: { '@id': SITE_URL + '#author' },
+      license: 'https://opensource.org/licenses/MIT'
+    },
+    {
+      '@type': 'Person',
+      '@id': SITE_URL + '#author',
+      name: 'Fabrizio Salmi',
+      url: 'https://github.com/fabriziosalmi',
+      sameAs: ['https://github.com/fabriziosalmi']
+    },
+    {
+      '@type': 'SoftwareSourceCode',
+      '@id': SITE_URL + '#source',
+      name: 'Proxmox VM Autoscale',
+      description: DESCRIPTION,
+      codeRepository: REPO,
+      programmingLanguage: 'Python',
+      runtimePlatform: 'Python 3.9+',
+      author: { '@id': SITE_URL + '#author' },
+      license: 'https://opensource.org/licenses/MIT',
+      isAccessibleForFree: true
+    },
+    {
+      '@type': 'SoftwareApplication',
+      '@id': SITE_URL + '#application',
+      name: 'Proxmox VM Autoscale',
+      description: DESCRIPTION,
+      applicationCategory: 'DeveloperApplication',
+      applicationSubCategory: 'Infrastructure automation',
+      operatingSystem: 'Linux (Debian/Proxmox VE)',
+      softwareRequirements: 'Python 3.9+, Proxmox VE 6.0+, SSH access',
+      url: SITE_URL,
+      downloadUrl: REPO + '/releases',
+      softwareHelp: SITE_URL + 'guide/',
+      image: OG_IMAGE,
+      author: { '@id': SITE_URL + '#author' },
+      isAccessibleForFree: true,
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+      license: 'https://opensource.org/licenses/MIT'
+    }
+  ]
+}
+
+export default defineConfig({
+  lang: 'en-US',
+  title: 'Proxmox VM Autoscale',
+  description: DESCRIPTION,
+  base: BASE,
+
+  cleanUrls: false,
+  lastUpdated: true,
+  metaChunk: true,
+
+  sitemap: {
+    hostname: SITE_URL
+  },
+
+  head: [
+    ['link', { rel: 'icon', href: BASE + 'favicon.svg', type: 'image/svg+xml' }],
+    ['meta', { name: 'theme-color', content: '#e57000' }],
+    ['meta', { name: 'author', content: 'Fabrizio Salmi' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'Proxmox VM Autoscale' }],
+    ['meta', { property: 'og:image', content: OG_IMAGE }],
+    ['meta', { property: 'og:locale', content: 'en_US' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:image', content: OG_IMAGE }],
+    ['script', { type: 'application/ld+json' }, JSON.stringify(jsonLd)]
+  ],
+
+  // Per-page canonical + Open Graph URL. Without these every page would
+  // advertise the site root, which is what makes duplicate-content warnings
+  // and wrong share previews show up.
+  transformPageData(pageData) {
+    const url = canonicalFor(pageData.relativePath)
+    const head: HeadConfig[] = pageData.frontmatter.head ?? []
+    head.push(
+      ['link', { rel: 'canonical', href: url }],
+      ['meta', { property: 'og:url', content: url }],
+      [
+        'meta',
+        {
+          property: 'og:title',
+          content: pageData.frontmatter.title ?? pageData.title ?? 'Proxmox VM Autoscale'
+        }
+      ],
+      [
+        'meta',
+        {
+          property: 'og:description',
+          content: pageData.frontmatter.description ?? pageData.description ?? DESCRIPTION
+        }
+      ]
+    )
+    pageData.frontmatter.head = head
+  },
+
+  themeConfig: {
+    logo: '/favicon.svg',
+    siteTitle: 'VM Autoscale',
+
+    nav: [
+      { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/configuration', activeMatch: '/reference/' },
+      { text: 'Security', link: '/security/', activeMatch: '/security/' },
+      {
+        text: 'v0.1.1',
+        items: [
+          { text: 'Changelog', link: '/reference/changelog' },
+          { text: 'Releases', link: REPO + '/releases' },
+          { text: 'Contributing', link: '/contributing' }
+        ]
+      }
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Getting started',
+          items: [
+            { text: 'Introduction', link: '/guide/' },
+            { text: 'Installation', link: '/guide/installation' },
+            { text: 'Your first scaling VM', link: '/guide/quick-start' }
+          ]
+        },
+        {
+          text: 'Core concepts',
+          items: [
+            { text: 'How scaling decisions are made', link: '/guide/how-it-works' },
+            { text: 'Hotplug and NUMA', link: '/guide/hotplug' },
+            { text: 'Host safety limits', link: '/guide/host-limits' }
+          ]
+        },
+        {
+          text: 'Features',
+          items: [
+            { text: 'Notifications', link: '/guide/notifications' },
+            { text: 'Billing tracking', link: '/guide/billing' }
+          ]
+        },
+        {
+          text: 'Running it',
+          items: [
+            { text: 'Operations', link: '/guide/operations' },
+            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+            { text: 'FAQ', link: '/guide/faq' }
+          ]
+        }
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Architecture', link: '/reference/architecture' },
+            { text: 'Python modules', link: '/reference/modules' },
+            { text: 'Known limitations', link: '/reference/limitations' },
+            { text: 'Changelog', link: '/reference/changelog' }
+          ]
+        }
+      ],
+      '/security/': [
+        {
+          text: 'Security',
+          items: [
+            { text: 'Threat model', link: '/security/' },
+            { text: 'Hardening guide', link: '/security/hardening' },
+            { text: 'Reporting a vulnerability', link: '/security/disclosure' }
+          ]
+        }
+      ]
+    },
+
+    socialLinks: [{ icon: 'github', link: REPO }],
+
+    editLink: {
+      pattern: REPO + '/edit/main/docs/:path',
+      text: 'Edit this page on GitHub'
+    },
+
+    outline: { level: [2, 3], label: 'On this page' },
+
+    search: {
+      provider: 'local',
+      options: {
+        detailedView: true
+      }
+    },
+
+    footer: {
+      message: [
+        `Released under the <a href="${REPO}/blob/main/LICENSE">MIT License</a>`,
+        `<a href="${BASE}privacy.html">Privacy</a>`,
+        `<a href="${BASE}security/disclosure.html">Security</a>`,
+        `<a href="${BASE}.well-known/security.txt">security.txt</a>`,
+        `<a href="${BASE}llms.txt">llms.txt</a>`,
+        `<a href="${BASE}sitemap.xml">Sitemap</a>`
+      ].join(' · '),
+      copyright: `Copyright © 2024–${new Date().getFullYear()} <a href="https://github.com/fabriziosalmi">Fabrizio Salmi</a>`
+    },
+
+    docFooter: { prev: 'Previous', next: 'Next' }
+  },
+
+  markdown: {
+    lineNumbers: false,
+    theme: { light: 'github-light', dark: 'github-dark' }
+  }
+})

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,48 @@
+/**
+ * Brand palette. Proxmox orange as the accent, kept desaturated in dark mode
+ * so code blocks and callouts stay readable rather than glowing.
+ */
+:root {
+  --vp-c-brand-1: #c25a00;
+  --vp-c-brand-2: #e57000;
+  --vp-c-brand-3: #e57000;
+  --vp-c-brand-soft: rgba(229, 112, 0, 0.14);
+
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #e57000 30%, #f0a500);
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    rgba(229, 112, 0, 0.5),
+    rgba(240, 165, 0, 0.35)
+  );
+  --vp-home-hero-image-filter: blur(48px);
+}
+
+.dark {
+  --vp-c-brand-1: #ff9d4d;
+  --vp-c-brand-2: #e57000;
+  --vp-c-brand-3: #c25a00;
+  --vp-c-brand-soft: rgba(229, 112, 0, 0.18);
+}
+
+/* Wide reference tables must scroll inside themselves rather than pushing the
+   page sideways. VitePress already sets `display: block; overflow-x: auto` for
+   this — do NOT override `display` here, or the scroll container disappears and
+   the right-hand columns become unreachable on narrow viewports. The only
+   change is letting a narrow table shrink to its content instead of always
+   filling the column. */
+.vp-doc table {
+  width: max-content;
+  max-width: 100%;
+}
+
+/* Keys and values in reference tables read better unwrapped. */
+.vp-doc td code,
+.vp-doc th code {
+  white-space: nowrap;
+}
+
+/* Slightly tighter feature cards on the home page. */
+.VPFeature .title {
+  font-size: 15px;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,5 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import './custom.css'
+
+export default DefaultTheme satisfies Theme

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,123 @@
+---
+title: Contributing
+description: How to contribute to Proxmox VM Autoscale — development setup, testing, code style, and what makes a change easy to review.
+---
+
+# Contributing
+
+Bug reports, fixes and features are all welcome. This page covers the practical parts; [`CONTRIBUTING.md`](https://github.com/fabriziosalmi/proxmox-vm-autoscale/blob/main/CONTRIBUTING.md) in the repository is the canonical version.
+
+## Before you start
+
+For anything beyond a bug fix, open an issue first. It is much less frustrating than finding out after the work is done that the direction was wrong.
+
+Worth reading first: [architecture](/reference/architecture) for how the pieces fit, and [known limitations](/reference/limitations) for what is already known — several of those are good first contributions.
+
+## Development setup
+
+```bash
+git clone https://github.com/YOUR_USERNAME/proxmox-vm-autoscale.git
+cd proxmox-vm-autoscale
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt pytest
+```
+
+You do not need a Proxmox host to work on most of this — the test suite mocks SSH throughout.
+
+## Running the tests
+
+```bash
+pytest -q                                    # everything
+pytest tests/test_vm_hotplug.py -v           # one file
+pytest -k cooldown -v                        # by name
+```
+
+114 tests, under a second. CI runs them on Python 3.9 through 3.12, plus `shellcheck -S warning install.sh`.
+
+## What a good change looks like
+
+**Tests that fail before the fix.** The most useful thing you can include is a test that demonstrates the bug against `main`. It proves the problem is real and stops it coming back.
+
+```bash
+git stash                                    # set your fix aside
+pytest tests/test_your_new_test.py           # should fail
+git stash pop
+pytest tests/test_your_new_test.py           # should pass
+```
+
+**No unrelated changes.** Reformatting a file you happened to open makes the actual change impossible to see.
+
+**Documentation updated in the same PR** when behaviour changes. The docs live in `docs/`; every page has an "Edit this page" link.
+
+**A changelog entry** under `## [Unreleased]` in `CHANGELOG.md` for anything user-visible.
+
+## Code style
+
+Match what is already there. Specifically:
+
+- 4-space indentation, no tabs
+- `snake_case` for functions and variables, `PascalCase` for classes
+- Docstrings on public methods, saying what the method does and what it returns
+- Type hints where the surrounding code uses them — `autoscale.py` and `billing_tracker.py` are annotated, `vm_manager.py` and `ssh_utils.py` largely are not; follow the file
+- Comments explain *why*, not *what*. The code already says what it does
+
+There is no linter in CI and no formatter config, so consistency is by hand.
+
+## Commit messages
+
+Conventional-commit prefixes, imperative mood:
+
+```
+fix: enforce scaling_limits from config.yaml
+feat: add per-VM threshold overrides
+docs: document the balloon fallback path
+test: cover NUMA detection with no numa line
+chore: bump paramiko
+```
+
+Explain the reasoning in the body when a one-line subject cannot carry it. A reader six months from now needs to know why, not just what.
+
+## Pull requests
+
+1. Branch from `main` — `fix/...` or `feat/...`
+2. Make the change, add tests, update docs
+3. `pytest -q` and `shellcheck -S warning install.sh` clean
+4. Push and open the PR
+
+In the description: what changed, why, how you verified it, and any behaviour change existing installations will notice.
+
+## Areas that need work
+
+Pulled from [known limitations](/reference/limitations), roughly by value:
+
+| Area | What is needed |
+|---|---|
+| **Metric parsing** | Replace the `pvesh` table scrape with `--output-format json`. Removes a whole class of silent failure |
+| **Non-RSA SSH keys** | Load Ed25519 and ECDSA keys, not just RSA |
+| **Billing reporting** | Wire `generate_period_report` into the loop on a period boundary; make the cost calculation honour uptime |
+| **Per-VM thresholds** | The config already shows them; the code does not read them |
+| **Host key verification** | Replace the auto-add policy with something verifiable |
+| **Dry-run mode** | Log what would happen without issuing commands |
+| **Metrics endpoint** | Prometheus exposition for cycle count, decisions, failures |
+
+## Reporting bugs
+
+[Open an issue](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/new/choose) with:
+
+- What you expected and what happened
+- Steps to reproduce
+- Proxmox version (`pveversion`), Python version, OS
+- Relevant log excerpts
+- Your config **with every credential removed**
+
+Security issues go through [responsible disclosure](/security/disclosure) instead — never a public issue.
+
+## Code of conduct
+
+Participation is covered by the [Code of Conduct](https://github.com/fabriziosalmi/proxmox-vm-autoscale/blob/main/CODE_OF_CONDUCT.md).
+
+## Licence
+
+Contributions are licensed under the [MIT Licence](https://github.com/fabriziosalmi/proxmox-vm-autoscale/blob/main/LICENSE), same as the project.

--- a/docs/guide/billing.md
+++ b/docs/guide/billing.md
@@ -1,0 +1,185 @@
+---
+title: Billing tracking
+description: How Proxmox VM Autoscale records spec changes for usage-based billing, exactly which parts run automatically, and how to generate a costed CSV report yourself.
+---
+
+# Billing tracking
+
+If you resell Proxmox capacity, autoscaling turns a fixed monthly spec into a variable one, and you probably want to bill for what a customer actually consumed. The `BillingTracker` module records every spec change with a timestamp and can turn a period into a costed CSV report.
+
+::: warning Read this before you invoice anyone
+Only part of this feature is wired into the running service. Enabling `billing` records data; it does **not** produce reports on its own, and the cost calculation currently ignores downtime. The [what is automatic](#what-is-automatic-and-what-is-not) section is precise about the boundary. Reconcile against your own records before billing a customer.
+:::
+
+## Configuration
+
+```yaml
+billing:
+  enabled: true
+  billing_period_days: 30
+  cost_per_cpu_core_per_hour: 0.01
+  cost_per_gb_ram_per_hour: 0.005
+  csv_output_dir: /var/log/vm_autoscale/billing/
+  webhook_script: ""
+  webhook_url: ""
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `false` | Instantiates the tracker at startup |
+| `billing_period_days` | `30` | Length of a period, counted backwards from now |
+| `cost_per_cpu_core_per_hour` | `0.01` | Currency-agnostic; you decide the unit |
+| `cost_per_gb_ram_per_hour` | `0.005` | Divided by 1024 internally to cost per MB |
+| `csv_output_dir` | `/var/log/vm_autoscale/billing/` | Created at startup; also holds the state file |
+| `webhook_script` | `""` | Executable receiving the report as JSON on stdin |
+| `webhook_url` | `""` | Endpoint receiving the report as a JSON `POST` |
+
+## What is automatic, and what is not
+
+| Capability | Automatic? |
+|---|---|
+| Recording a spec change after each successful scaling action | **Yes** |
+| Persisting records to `billing_data.json` | **Yes** |
+| Recording VM start/stop events | **No** — nothing in the service calls it |
+| Generating a CSV report | **No** — nothing in the service calls it |
+| Firing `webhook_script` / `webhook_url` | **No** — only reachable via report generation |
+| Setting a human-readable VM name | **No** |
+
+So with `enabled: true` you get a growing `billing_data.json` full of spec changes, and nothing else, until you invoke the reporting yourself. `record_vm_state_change`, `generate_period_report`, `export_csv`, `run_webhook` and `set_vm_name` are all public API — they are simply not called by `autoscale.py`. See [known limitations](/reference/limitations#billing-reports-are-not-generated-automatically).
+
+## The data file
+
+```
+/var/log/vm_autoscale/billing/billing_data.json
+```
+
+```json
+{
+  "spec_changes": {
+    "101": [
+      { "timestamp": "2026-09-01T09:14:22.104512", "cpu_cores": 2, "ram_mb": 4096 },
+      { "timestamp": "2026-09-01T11:02:07.883210", "cpu_cores": 3, "ram_mb": 4096 }
+    ]
+  },
+  "state_changes": {},
+  "vm_names": {}
+}
+```
+
+::: warning It grows without bound
+The whole file is rewritten on every record, and nothing prunes old entries. A busy fleet accumulates one entry per scaling action forever, and each write serialises the entire history. Archive and truncate it periodically:
+
+```bash
+sudo systemctl stop vm_autoscale.service
+sudo mv /var/log/vm_autoscale/billing/billing_data.json \
+        /var/backups/billing_data-$(date +%F).json
+sudo systemctl start vm_autoscale.service
+```
+
+Timestamps are naive local time (`datetime.now()`), with no timezone and no DST handling. Reports spanning a DST boundary will be off by an hour.
+:::
+
+## Generating a report
+
+Run this on the machine hosting the service, as a user who can read `csv_output_dir`:
+
+```python
+#!/usr/bin/env python3
+"""Generate a billing CSV for every configured VM for the current period."""
+import logging
+import sys
+
+import yaml
+
+sys.path.insert(0, "/usr/local/bin/vm_autoscale")
+from billing_tracker import BillingTracker
+
+logging.basicConfig(level=logging.INFO)
+
+with open("/usr/local/bin/vm_autoscale/config.yaml") as fh:
+    config = yaml.safe_load(fh)
+
+tracker = BillingTracker(config, logging.getLogger("billing"))
+
+for vm in config["virtual_machines"]:
+    report = tracker.generate_period_report(str(vm["vm_id"]))
+    if report:
+        print(f"VM {report.vm_id}: {report.total_cost:.4f} "
+              f"({report.period_start:%Y-%m-%d} → {report.period_end:%Y-%m-%d})")
+```
+
+`generate_period_report` calculates the period, writes the CSV, and fires the webhook if one is configured. Store the script **outside** `/usr/local/bin/vm_autoscale/` — the installer deletes that directory on reinstall.
+
+Run it monthly:
+
+```
+0 2 1 * * root /usr/local/bin/vm-autoscale-billing.py >> /var/log/vm_autoscale/billing/cron.log 2>&1
+```
+
+## The CSV
+
+```
+billing_101_20260806_20260905.csv
+```
+
+Sections: summary (VMID, name, period), resource statistics (min/max/average cores and RAM), uptime statistics, total cost, then the full list of spec changes.
+
+Note that "min/max/average" are computed across **recorded change events**, not weighted by time. Ten scale-ups in one hour and one steady week at the resulting spec average out to something that is not the average spec. The `total_cost` figure *is* time-weighted; the statistics are not.
+
+## How cost is calculated
+
+Each spec is charged for the wall-clock interval it was in effect:
+
+```
+cost = Σ (cores × cost_per_cpu_core_per_hour × hours_at_that_spec)
+     + Σ (ram_mb × (cost_per_gb_ram_per_hour ÷ 1024) × hours_at_that_spec)
+```
+
+The first recorded spec is treated as being in effect from `period_start`, and the last one runs to `period_end`.
+
+::: danger Downtime is billed as uptime
+The cost calculation does not consult the uptime records — and since nothing records VM state changes in the first place, uptime is reported as 100% regardless. A VM powered off for a week is billed for that week at its last known spec. This is a real defect, not a pricing policy; see [known limitations](/reference/limitations#downtime-is-billed-as-uptime).
+:::
+
+Also: a VM that never scaled during a period has no spec records for it, and is billed **zero** — not "the spec it sat at the whole time". Usage-based billing here means *change*-based recording, so a customer on a stable spec produces no data.
+
+## Webhooks
+
+Both fire from `generate_period_report`, after the CSV is written.
+
+**Script** — executed with the report JSON on stdin, 60-second timeout:
+
+```bash
+#!/bin/bash
+# /usr/local/bin/vm-autoscale-billing-hook.sh
+jq -r '"\(.vm_id),\(.total_cost),\(.period_end)"' >> /var/lib/billing/ledger.csv
+```
+
+```yaml
+billing:
+  webhook_script: /usr/local/bin/vm-autoscale-billing-hook.sh
+```
+
+The path must exist and be executable, otherwise it is skipped silently.
+
+**URL** — a JSON `POST` with a 30-second timeout:
+
+```yaml
+billing:
+  webhook_url: https://billing.example.com/api/usage
+```
+
+There is no authentication header, no signature and no retry. Put it behind something that authenticates by source IP or mTLS, and do not treat delivery as guaranteed.
+
+## Report fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `vm_id` | string | |
+| `vm_name` | string | `VM-<id>` unless `set_vm_name` was called |
+| `period_start` / `period_end` | ISO 8601 | Naive local time |
+| `min_cpu_cores`, `max_cpu_cores`, `avg_cpu_cores` | number | Across change events, not time-weighted |
+| `min_ram_mb`, `max_ram_mb`, `avg_ram_mb` | number | Same caveat |
+| `total_uptime_hours`, `total_downtime_hours`, `uptime_percentage` | number | Currently always full uptime |
+| `spec_changes` | array | Every record in the period |
+| `total_cost` | number | Time-weighted, rounded to 4 decimals |

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,0 +1,134 @@
+---
+title: FAQ
+description: Frequently asked questions about Proxmox VM Autoscale — scope, safety, tuning, LXC support, clustering and production readiness.
+---
+
+# FAQ
+
+## Scope
+
+### Does it work with LXC containers?
+
+No. It drives `qm`, which is QEMU/KVM only. Use [proxmox-lxc-autoscale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale) for containers, or [proxmox-lxc-autoscale-ml](https://github.com/fabriziosalmi/proxmox-lxc-autoscale-ml) for the ML-driven variant.
+
+### Can it create or destroy VMs?
+
+No. It only resizes VMs you list explicitly. No cloning, no migration, no provisioning.
+
+### Can it scale disk or network?
+
+No. CPU cores, vCPUs and memory only.
+
+### Does it need an agent inside the guest?
+
+No. Everything is read from the hypervisor. For memory changes to apply live the guest does need the **virtio balloon driver**, but that is a driver, not an agent.
+
+### Does it use the Proxmox API?
+
+No. It SSHes in and runs `qm` and `pvesh` as shell commands. There is no API token and no `pvesh` REST client — `pvesh` here is the CLI.
+
+## Setup
+
+### Must it run on a Proxmox node?
+
+No. Anywhere with SSH access to your nodes works, and running it off-node means a node reboot does not take the autoscaler with it. The installer assumes on-node because that is the common case.
+
+### Can one instance manage several nodes?
+
+Yes — list them all under `proxmox_hosts`. They are processed sequentially in one cycle.
+
+### Does it work on a Proxmox cluster?
+
+It works on the nodes of a cluster, treating each as an independent host. It has no cluster awareness: no quorum check, no migration, no cluster-wide capacity view.
+
+### Can I use an Ed25519 SSH key?
+
+Not currently. The key file is loaded specifically as an RSA key. Use an RSA key or password authentication — see [known limitations](/reference/limitations#only-rsa-ssh-keys-are-supported).
+
+### Does it need root on the Proxmox host?
+
+In practice yes. Every action is `qm` or `pvesh`, which require privileges a normal user does not have. There is no least-privilege mode; the [threat model](/security/) is honest about what that means.
+
+## Behaviour
+
+### How fast does it react?
+
+At worst one `check_interval` (default 300 s) before a spike is even noticed, then one step per `scale_cooldown`. Going from 2 to 8 cores takes six steps. This is not a service for reacting to a traffic spike in seconds.
+
+### Can I make the steps bigger?
+
+Not through configuration. Step sizes are fixed at 1 core and 512 MB in `vm_manager.py`.
+
+### Can I set different thresholds per VM?
+
+No. `config.yaml` shows a `thresholds:` block inside each VM entry, but the code reads only the global `scaling_thresholds`. The per-VM block is inert. See [known limitations](/reference/limitations#per-vm-thresholds-are-ignored).
+
+### What happens if the service is restarted mid-cooldown?
+
+The cooldown is forgotten. Timers are in memory only, so the first cycle after a restart can scale immediately.
+
+### Does it scale VMs that are powered off?
+
+No — a stopped guest is skipped before anything else happens.
+
+### What if a VM's usage cannot be read?
+
+It is treated as `0.0%`, which is below any sane `low` threshold, so the VM is scaled **down**. This is a genuine hazard, not a design choice — watch for `CPU usage not found in output` in the log.
+
+### Does it undo its changes when stopped?
+
+No. Guests stay wherever the last scaling action left them, including any `hotplug` and `numa` flags the service set.
+
+## Tuning
+
+### Good starting thresholds?
+
+The shipped 20/80 for CPU and 25/85 for RAM are sensible. The important thing is the width of the gap, not the exact numbers — a narrow band causes oscillation.
+
+### Why does my idle VM never scale down?
+
+An idle guest is rarely at 0% CPU: background daemons, cron, monitoring agents typically keep it at 3–10%. If your `low` is 20 and the guest idles at 22, it never crosses. Watch a few cycles of `VM 101 current usage` lines and set `low` below the observed floor.
+
+### Why does everything scale down at once after a restart?
+
+Cooldowns are cleared on restart, so every VM is immediately eligible. If several are below their `low` threshold they all step down in the first cycle. That is expected — but if it happens on a busy fleet, check for the `usage not found` warnings first.
+
+### Should `scale_cooldown` be shorter than `check_interval`?
+
+There is no point. Decisions only happen at poll time, so the effective interval is `max(check_interval, scale_cooldown)`.
+
+## Safety
+
+### Can it take a host down?
+
+`host_limits` is designed to prevent that: no VM on a node above its ceiling gets scaled. The gate also blocks scale-*down*, though, so a saturated node cannot shrink its idle guests either.
+
+### Can it break a running VM?
+
+Realistically, the two risks are memory and CPU removal. Ballooning memory away from a guest that is genuinely using it can push it into swap or trigger the OOM killer — keep `min_ram_mb` at a value the workload actually survives. Removing a vCPU is unreliable on some guests, Windows especially.
+
+### Is there a dry-run mode?
+
+No. If the service is running and a threshold is crossed, the command is executed. The nearest approximation is `scaling_enabled: false` on every VM, which produces the monitoring log lines with no actions.
+
+### Is it safe for production?
+
+It is a small single-process service with 114 unit tests, run by its author and by others across 302 stars and 23 forks. It is also alpha-versioned software that holds root credentials, has no dry-run, and has known defects documented on the [limitations](/reference/limitations) page. Read that page and the [threat model](/security/), pilot it on VMs you can afford to disturb, and decide for yourself.
+
+## Project
+
+### What Python version?
+
+3.9 or newer. CI tests 3.9 through 3.12.
+
+### Which version should I run?
+
+The latest release, or `main`. Note that the tags are not in chronological order — `v1.2.0` predates `v0.1.1` despite the numbering. `v0.1.1` is the current release.
+
+### How do I report a bug or a vulnerability?
+
+Bugs: [GitHub issues](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/new/choose). Vulnerabilities: **not** as a public issue — see [reporting a vulnerability](/security/disclosure).
+
+### Is commercial support available?
+
+Yes. Paid support, custom development and consulting around infrastructure automation, hardening and monitoring: **fabrizio.salmi@gmail.com**.

--- a/docs/guide/host-limits.md
+++ b/docs/guide/host-limits.md
@@ -1,0 +1,68 @@
+---
+title: Host safety limits
+description: How host_limits prevents Proxmox VM Autoscale from pushing an already-saturated node further, and the edge cases in how the gate is applied.
+---
+
+# Host safety limits
+
+Autoscaling that ignores the hypervisor is a way to overcommit a node until everything on it suffers. `host_limits` is the guard against that.
+
+```yaml
+host_limits:
+  max_host_cpu_percent: 90
+  max_host_ram_percent: 90
+```
+
+## How the check works
+
+Before any VM on a node is evaluated, the service asks the node about itself:
+
+```bash
+pvesh get /nodes/$(hostname)/status --output-format json
+```
+
+and computes:
+
+- **CPU** — the `cpu` field (a fraction of total capacity) × 100.
+- **RAM** — `memory.used / memory.total × 100`.
+
+If either exceeds its ceiling, that VM is skipped for this cycle:
+
+```
+[WARNING] Host CPU usage exceeds maximum allowed limit: 94.10% > 90%
+[WARNING] Host pve1 resources maxed out. Skipping scaling.
+```
+
+The check runs **per VM**, not once per host, so a saturated node produces one warning pair per configured VM per cycle. Noisy, but it also means the reading is fresh for each decision.
+
+## Two behaviours worth knowing
+
+### The gate blocks scale-down too
+
+The check sits before the usage read, so a node above its ceiling blocks *all* scaling on it — including shrinking an idle guest, which is exactly the action that would give the node back some headroom.
+
+If your nodes routinely sit near the ceiling, consider raising `max_host_ram_percent`. Proxmox hosts with ZFS ARC or a large page cache legitimately run at high memory utilisation.
+
+### `used` is not `total - free`
+
+RAM is computed from the node's `used` field, which excludes reclaimable buff/cache and matches the Proxmox web UI. Before 0.1.1 the calculation used `free + cached` as available memory, so a node with a warm cache reported ~90% when the UI showed ~66% — and every scaling action on it was suppressed. If you are on an older version and nothing ever scales, that is very likely the cause.
+
+## Choosing the ceilings
+
+| Setting | Reasonable range | Notes |
+|---|---|---|
+| `max_host_cpu_percent` | 80–90 | Proxmox reports load across all cores; brief 100% spikes are normal, and the sample is instantaneous |
+| `max_host_ram_percent` | 85–95 | With ZFS, ARC counts as used. Check `arc_summary` before deciding this is a real ceiling |
+
+Both are required keys — there is no default. A missing `host_limits` section raises a `KeyError` on the first VM processed, surfacing as `Error processing VM ...` in the log.
+
+## Multi-node behaviour
+
+Limits are global, not per host: the same two numbers apply to every node in `proxmox_hosts`. If one node is much smaller or much busier than the rest, you cannot express that today. The workaround is to run a second instance of the service with its own config file and its own systemd unit.
+
+## What is not checked
+
+- **Storage.** Disks are never scaled, so free space is not consulted. A full storage pool will not stop CPU or RAM scaling.
+- **Ballooning pressure across guests.** Each VM is considered on its own; the service does not reason about total committed memory versus physical memory.
+- **Node quorum or cluster state.** A node that has lost quorum still answers `pvesh get /nodes/.../status`, and scaling proceeds.
+- **Other consumers.** Anything running on the node outside Proxmox's accounting is invisible.

--- a/docs/guide/hotplug.md
+++ b/docs/guide/hotplug.md
@@ -1,0 +1,138 @@
+---
+title: Hotplug and NUMA
+description: Why Proxmox VM Autoscale needs hotplug and NUMA to change a running VM, what applies live, what needs a reboot, and what auto_configure_hotplug changes on your guests.
+---
+
+# Hotplug and NUMA
+
+Whether a scaling action takes effect immediately or waits for the next reboot is decided entirely by two guest settings. This page explains which, why, and what the service does about them.
+
+## The two settings
+
+```bash
+qm set <vmid> -hotplug cpu,memory,network,disk,usb
+qm set <vmid> -numa 1
+```
+
+Or in the web UI: **VM → Options → Hotplug** and **VM → Hardware → Processors → Enable NUMA**.
+
+| Setting | Enables | Applies without reboot? |
+|---|---|---|
+| `hotplug: cpu` | Adding/removing **vCPUs** on a running guest | Yes, the hotplug flag itself does |
+| `hotplug: memory` | Memory changes on a running guest | Yes |
+| `numa: 1` | Memory hotplug to actually function | **No** — needs a guest reboot |
+
+The trap is the last row. NUMA is part of the virtual machine topology, so turning it on does nothing until the guest is power-cycled. A VM with `hotplug: memory` but `numa: 0` looks configured and is not.
+
+## What applies live
+
+| Change | Live with hotplug + NUMA | Otherwise |
+|---|---|---|
+| **vCPU count** (`-vcpus`) | Yes | n/a |
+| **Core count** (`-cores`) | **No — always needs a reboot** | Needs a reboot |
+| **RAM** (`-balloon`) | Yes | n/a |
+| **RAM** (`-memory`) | Needs a reboot | Needs a reboot |
+
+`cores` is the number of CPUs the virtual motherboard has sockets for; `vcpus` is how many of them are plugged in right now. Only the second can change on a running guest, and it can never exceed the first.
+
+## How the service uses this
+
+### Scaling CPU up
+
+```
+if running and hotplug:cpu
+    if vcpus < cores      → qm set -vcpus (vcpus + 1)          # live
+    else                  → qm set -cores (cores + 1)          # needs reboot
+                            qm set -vcpus (vcpus + 1)          # live, warned
+else
+    qm set -cores, qm set -vcpus                               # warning logged
+```
+
+So the first few scale-ups on a guest with headroom (say 4 cores, 2 vCPUs) are genuinely live. Once vCPUs catch up with cores, each further step raises the core count too — and that part only materialises after a reboot. The log says so explicitly:
+
+```
+[WARNING] VM 101: Increased cores to 5 (requires reboot for full effect)
+          and vCPUs to 5 (hotplug applied).
+```
+
+::: tip Give guests headroom in `cores`
+Provision a guest with more `cores` than it needs and fewer `vcpus`, e.g. `cores: 8, vcpus: 2`. Every scale-up inside that range is fully live, and you never hit the reboot boundary.
+:::
+
+### Scaling CPU down
+
+vCPUs are reduced first, which takes effect immediately. The core count is then also reduced, but only when it would stay at or above both the new vCPU count and `min_cores`. That part waits for a reboot.
+
+::: warning CPU hot-unplug depends on the guest OS
+Removing a vCPU is far less reliable than adding one. Linux generally copes; some workloads pinned to a CPU do not; Windows guests frequently refuse. QEMU accepts the command either way and the service logs success. Verify with `nproc` inside a guest you care about.
+:::
+
+### Scaling RAM
+
+With hotplug **and** NUMA on a running guest, the service sets the **balloon** value:
+
+```bash
+qm set <vmid> -balloon 4096
+```
+
+The balloon driver inside the guest inflates or deflates to reach the target, so memory changes without a reboot. In every other case the service falls back to `-memory`, which only applies on next boot, and logs a warning saying so.
+
+::: warning The balloon driver has to be present and working
+Ballooning needs `virtio_balloon` in the guest. Without it — most bare Windows installs before the VirtIO drivers are installed, some minimal container-style images — the command succeeds at the QEMU level and nothing happens inside the guest. Reclaiming memory from a guest that is genuinely using it can also drive it into swap or trigger the OOM killer.
+:::
+
+### Why `min_ram_mb` should stay at 1024
+
+NUMA-enabled guests behave badly with very little memory; the shipped config sets `min_ram_mb: 1024` specifically for that. The step size is 512 MB, so a floor of 1024 also keeps the scale-down path from landing on awkward values.
+
+## `auto_configure_hotplug`
+
+```yaml
+auto_configure_hotplug: true    # default
+```
+
+When enabled, the first time the service handles a VM it inspects `qm config` and, if hotplug or NUMA is missing, issues:
+
+```bash
+qm set <vmid> -hotplug cpu,memory,network,disk,usb -numa 1
+```
+
+Then it logs:
+
+```
+[INFO] VM 101: Enabling hotplug for cpu,memory,network,disk,usb
+[INFO] VM 101: Enabling NUMA for memory hotplug support
+[INFO] VM 101: Hotplug configuration updated.
+       Note: NUMA changes require a VM restart to take effect.
+```
+
+### What to know before leaving it on
+
+- **It modifies your VM configuration without asking.** On a fleet you did not build yourself, that may not be welcome.
+- **It enables hotplug for `network,disk,usb` too**, not just CPU and memory. That is broader than the autoscaler needs.
+- **NUMA will not work until you reboot the guest.** Until then memory scaling silently falls back to `-memory` + reboot. The service tells you once, in the log, at the moment it makes the change.
+- **It runs once per VM per service lifetime.** After the fix that caches VM managers across cycles, this is a single check at startup rather than two extra `qm config` calls per VM on every poll.
+- **Failures are non-fatal.** If `qm set` fails the service logs a warning and carries on with whatever the guest currently supports.
+
+Set it to `false` if you would rather configure guests deliberately:
+
+```yaml
+auto_configure_hotplug: false
+```
+
+## Verifying a guest is genuinely live-scalable
+
+```bash
+# On the node
+qm config 101 | grep -E 'hotplug|numa|cores|vcpus|memory|balloon'
+```
+
+You want to see `hotplug:` containing both `cpu` and `memory`, and `numa: 1`.
+
+```bash
+# Inside the guest — has it been rebooted since numa was enabled?
+lscpu | grep -i numa
+dmesg | grep -i balloon
+```
+
+If `numa: 1` is in the VM config but `lscpu` shows no NUMA node, the guest has not been rebooted since the change and memory hotplug is not actually available yet.

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -1,0 +1,149 @@
+---
+title: How scaling decisions are made
+description: The full decision path Proxmox VM Autoscale takes each cycle — gates, thresholds, step sizes, limits and per-resource cooldowns.
+---
+
+# How scaling decisions are made
+
+Every decision this service makes comes from one pass of the logic below. There is no state carried between cycles other than the cooldown timers.
+
+## The cycle
+
+```
+every check_interval seconds
+│
+└─ for each host in proxmox_hosts
+   └─ for each VM in virtual_machines where proxmox_host == host.name
+      │                                    and scaling_enabled == true
+      │
+      ├─ open SSH connection to the host
+      │
+      ├─ GATE 1  is the guest running?          qm status <id> --verbose
+      │          └─ no  → skip this VM
+      │
+      ├─ GATE 2  does the host have headroom?   pvesh get /nodes/<n>/status
+      │          └─ no  → skip this VM, log a warning
+      │
+      ├─ read CPU% and RAM% for the guest       pvesh get /cluster/resources
+      │
+      ├─ if cpu_scaling:  evaluate CPU thresholds → maybe scale
+      ├─ if ram_scaling:  evaluate RAM thresholds → maybe scale
+      │
+      └─ close SSH connection
+```
+
+Both gates are checked **before** any usage is read, and both are hard stops for that VM in that cycle. A VM that is powered off costs one `qm status` call and nothing else.
+
+## Gate 1 — is the guest running?
+
+`qm status <vmid> --verbose` is parsed for the literal string `status: running`. Retried up to three times with an increasing delay, because a node under load occasionally times out. If all three attempts fail, the VM is treated as not running and skipped.
+
+## Gate 2 — does the host have headroom?
+
+Read from `pvesh get /nodes/$(hostname)/status --output-format json`:
+
+- **CPU** — the node's `cpu` field, a fraction, multiplied by 100.
+- **RAM** — `memory.used / memory.total × 100`.
+
+::: info Why `used` and not `total - free`
+`used` excludes reclaimable buff/cache and matches what the Proxmox web UI shows. An earlier version computed availability from `free + cached`, which made a node with a warm page cache look 90% full when it was really at 66%, silently suppressing all scaling. Fixed in [0.1.1](/reference/changelog).
+:::
+
+If either figure exceeds `host_limits.max_host_cpu_percent` or `max_host_ram_percent`, the whole VM is skipped — including scale **down**, which is arguably backwards, since shrinking a guest is exactly what you want on a saturated node. Worth knowing if your node sits near its ceiling.
+
+## Reading guest usage
+
+```bash
+pvesh get /cluster/resources | grep 'qemu/<vmid>' | awk -F '│' '{print $6, $15, $16}'
+```
+
+The three fields are CPU percentage, maximum memory and used memory. CPU is taken from the leading percentage; RAM percentage is computed as used ÷ maximum, with MiB and GiB units normalised.
+
+::: warning This parsing is fragile
+It depends on `pvesh`'s human-readable table: on the box-drawing separator, on those exact column positions, and on `grep` matching. `grep 'qemu/101'` also matches VMID `1010` and `1011`. If usage always reads as `0.0%` on your Proxmox version, this is almost certainly why — see [known limitations](/reference/limitations#metric-parsing-is-format-sensitive).
+:::
+
+When usage cannot be parsed the service logs a warning and uses `0.0`. Zero is below every sensible `low` threshold, so **an unreadable metric looks identical to an idle guest** and triggers a scale *down*. This is the mechanism behind several historical "scaled down to minimum for no reason" reports.
+
+## The thresholds
+
+CPU and RAM are evaluated independently, each against `scaling_thresholds`:
+
+| Condition | Action |
+|---|---|
+| `usage > high` | Scale that resource **up** one step |
+| `low ≤ usage ≤ high` | Nothing — this is the dead band |
+| `usage < low` | Scale that resource **down** one step |
+
+Comparisons are strict (`>` and `<`), so a value sitting exactly on a threshold does nothing.
+
+::: tip Keep the dead band wide
+The gap between `low` and `high` is your only defence against oscillation. With `low: 60` and `high: 70`, a guest hovering near 65% will bounce up and down forever, each flap costing a `qm set`. The shipped defaults (20/80 for CPU, 25/85 for RAM) are wide for good reason.
+:::
+
+CPU is always evaluated before RAM. If CPU scaling raises an exception the service logs it and still proceeds to RAM.
+
+## Step sizes
+
+Steps are fixed and not configurable:
+
+| Resource | Step |
+|---|---|
+| CPU | 1 core / 1 vCPU |
+| RAM | 512 MB |
+
+One step per resource per cycle. Recovering from a large, sudden jump therefore takes several cycles: going from 2 to 8 cores needs six cycles, each separated by at least `scale_cooldown`.
+
+## Limits
+
+Steps are clamped by `scaling_limits`:
+
+```yaml
+scaling_limits:
+  min_cores: 1
+  max_cores: 8
+  min_ram_mb: 1024
+  max_ram_mb: 16384
+```
+
+At a boundary the corresponding direction becomes a no-op: `No CPU scaling required.` in the log, no notification, and — importantly — **no cooldown consumed**.
+
+::: danger These limits were ignored before the fix
+Until recently the code looked these values up under names that do not exist in `config.yaml`, so every installation ran on the hardcoded defaults 1–8 cores and 512–16384 MB regardless of what you wrote. If you are upgrading from an older version, your configured limits are about to start applying for the first time — re-read them before you upgrade. See the [changelog](/reference/changelog).
+:::
+
+## Cooldowns
+
+`scale_cooldown` (default 300 s) is the minimum time between two scaling actions **on the same resource of the same VM**.
+
+Three properties are worth stating precisely:
+
+1. **CPU and RAM have separate timers.** A CPU change does not delay a RAM change. (They shared one timer before; that is what made RAM appear to stop scaling whenever CPU was active — [issue #30](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/30).)
+2. **Only a real change starts the timer.** Crossing a threshold while already at a limit changes nothing and rate-limits nothing.
+3. **Timers live in memory.** They survive between cycles, but a service restart clears them. After `systemctl restart`, the first cycle can scale immediately.
+
+The effective interval between two changes to the same resource is therefore `max(check_interval, scale_cooldown)` rounded up to a cycle boundary. Setting `scale_cooldown` below `check_interval` has no effect.
+
+## Applying the change
+
+What actually reaches the hypervisor depends on the guest's hotplug state — the [hotplug and NUMA](/guide/hotplug) page covers this in full. Summarised:
+
+| Guest state | CPU up | RAM change |
+|---|---|---|
+| Running, hotplug + NUMA on | `qm set -vcpus` (live), `-cores` if vCPUs are already at the core count | `qm set -balloon` (live) |
+| Running, hotplug on, NUMA off | `-cores` + `-vcpus`, warning logged | `qm set -memory`, needs reboot |
+| Running, no hotplug | `-cores` + `-vcpus`, warning logged | `qm set -memory`, needs reboot |
+| Stopped | `-cores` + `-vcpus` | `qm set -memory` |
+
+::: warning A logged success is not a confirmed change
+The service logs `RAM balloon set to 4096 MB` after the command returns. It does not verify that the guest honoured it. A guest without a working balloon driver, or one whose kernel refuses a CPU hot-add, will report success in the log and change nothing. Check `qm config` and the guest itself when it matters.
+:::
+
+## After a change
+
+- The action is logged at `INFO`.
+- A notification goes out via every configured channel, priority 7 for scale-up and 5 for scale-down ([notifications](/guide/notifications)).
+- If billing is enabled, the new spec is recorded with a timestamp ([billing](/guide/billing)).
+- The cooldown timer for that resource starts.
+
+Errors while processing a VM are caught per-VM: they are logged, sent as a priority-9 notification, and the loop moves on to the next VM. An unexpected error in the outer loop is logged at priority 10 and the service waits 60 seconds before retrying.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,65 @@
+---
+title: Introduction
+description: What Proxmox VM Autoscale does, what it deliberately does not do, and the assumptions it makes about your Proxmox environment.
+---
+
+# Introduction
+
+Proxmox VM Autoscale is a long-running Python service that adjusts the CPU cores and RAM of Proxmox VE virtual machines based on how much of each they are actually using.
+
+It runs as a systemd unit, connects to one or more Proxmox nodes over SSH, and drives the standard `qm` and `pvesh` command-line tools. There is no agent inside the guests and no Proxmox API token: everything happens through an SSH session as a user who can run `qm`.
+
+## The loop, in one paragraph
+
+Every `check_interval` seconds the service walks the VMs listed in `config.yaml`. For each one it confirms the guest is running, checks that the **host** still has headroom, reads the guest's current CPU and RAM usage, and compares those numbers against your thresholds. If usage is above the high mark it adds one core or 512 MB; if it is below the low mark it removes one. Limits and a per-resource cooldown bound how far and how fast that can go. Any actual change is logged and, if you configured it, pushed to Gotify or emailed.
+
+That is the whole design. The rest of the documentation is about the details that decide whether it behaves well on your hardware.
+
+## What it does
+
+- **Vertical scaling of CPU cores and vCPUs** on a running or stopped guest.
+- **Vertical scaling of RAM**, via the balloon device when hotplug and NUMA allow it, otherwise as a config change that needs a reboot.
+- **Multi-host operation** — several Proxmox nodes in one config file, each with its own SSH credentials and port.
+- **Host-level safety gating** so a busy node does not get pushed further.
+- **Hotplug and NUMA auto-configuration**, optional, so guests become live-scalable without you touching each one by hand.
+- **Gotify and SMTP notifications** on scaling actions and errors.
+- **Spec-change recording** for usage-based billing, with a costed CSV report.
+
+## What it does not do
+
+Being explicit about this saves a lot of disappointment:
+
+- **No horizontal scaling.** It never creates, clones, destroys or migrates a VM. It only resizes the ones you list.
+- **No LXC containers.** Use the sibling project [proxmox-lxc-autoscale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale) for those.
+- **No disk, network or GPU scaling.** CPU cores, vCPUs and memory only.
+- **No prediction or trend analysis.** Decisions come from a single instantaneous sample per cycle. There is no smoothing, no moving average and no seasonality — a one-off spike between two polls is invisible, and a spike caught by a poll is acted on immediately.
+- **No dry-run mode.** If the service is running and a threshold is crossed, `qm set` is executed.
+- **No per-VM thresholds.** `config.yaml` shows a `thresholds:` block inside each VM entry, but the code reads only the global `scaling_thresholds`. See [known limitations](/reference/limitations#per-vm-thresholds-are-ignored).
+- **No high availability.** It is a single process. If it dies, systemd restarts it and the in-memory cooldown state starts over.
+
+## Assumptions it makes
+
+| Assumption | Why it matters |
+|---|---|
+| You can SSH to each Proxmox node as a user who may run `qm set` — in practice `root` | Every action is a shell command; there is no least-privilege mode today |
+| Guests are QEMU/KVM VMs, not containers | Usage is read from `qemu/<vmid>` rows in `pvesh get /cluster/resources` |
+| `pvesh` output format is stable on your Proxmox version | Usage parsing is text-based and version-sensitive — see [limitations](/reference/limitations#metric-parsing-is-format-sensitive) |
+| Guests you want live-scaled have hotplug **and** NUMA on | Without both, memory changes need a reboot to apply |
+| Load is bursty and uncorrelated across VMs | If everything peaks together, the host ceiling blocks scaling and you simply need more hardware |
+
+## Requirements
+
+- **Proxmox VE 6.0 or newer** on the target nodes.
+- **Python 3.9 or newer** on the machine running the service. (CI tests 3.9 through 3.12. The README's older "3.6+" claim is not backed by any test run.)
+- **`paramiko`, `PyYAML`, `requests`** — see `requirements.txt`.
+- **SSH reachability** from the service to every node in the config.
+
+::: tip Where to run it
+The service can run *on* a Proxmox node (simplest, and what the installer assumes) or on a separate Linux box that has SSH access to all of them. Running it off-node means a node reboot does not take the autoscaler down with it — but it also means the autoscaler's credentials live somewhere else that must be protected just as well.
+:::
+
+## Next steps
+
+- [Install it](/guide/installation) — installer, or manual setup if you would rather not pipe a script into bash.
+- [Get one VM scaling](/guide/quick-start) — the smallest useful configuration, and how to prove it works.
+- [Understand the decision logic](/guide/how-it-works) — thresholds, step sizes, limits, cooldowns.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,150 @@
+---
+title: Installation
+description: Install Proxmox VM Autoscale with the installer script or by hand, including what the installer changes on your system and how to uninstall it.
+---
+
+# Installation
+
+Two routes: the installer script, or a manual install. The manual route is longer but you see every change, which matters for a service that will hold root credentials.
+
+## What gets installed
+
+Either way you end up with the same layout:
+
+| Path | Contents | Mode |
+|---|---|---|
+| `/usr/local/bin/vm_autoscale/` | Python sources, `config.yaml`, `logging_config.json` | `755` |
+| `/usr/local/bin/vm_autoscale/config.yaml` | Your hosts, VMs, credentials | **`600`, root-owned** |
+| `/etc/vm_autoscale/config.yaml.backup` | Copy of the previous config, kept across reinstalls | `600` in `700` dir |
+| `/etc/systemd/system/vm_autoscale.service` | systemd unit | `644` |
+| `/var/log/vm_autoscale.log` | Service log | created on first run |
+
+## Option A — installer script
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/fabriziosalmi/proxmox-vm-autoscale/main/install.sh)
+```
+
+::: danger You are piping a remote script into a root shell
+This fetches whatever is on `main` at that moment and runs it as root, with no signature and no checksum. That is a real supply-chain exposure, not a theoretical one. If you would rather not, [download and read it first](#reviewing-the-installer) or use the [manual install](#option-b-manual-install).
+:::
+
+The script must run as root. It will:
+
+1. Create `/etc/vm_autoscale/` (mode `700`) and back up any existing `config.yaml` into it.
+2. `apt-get install` `python3`, `curl`, `bash`, `git`, `python3-paramiko`, `python3-yaml`, `python3-requests`, `python3-cryptography`.
+3. **Delete** `/usr/local/bin/vm_autoscale/` if it exists, then clone the repository into it.
+4. Restore your backed-up `config.yaml` over the shipped example.
+5. `pip3 install -r requirements.txt`.
+6. Set permissions — including locking `config.yaml` to mode `600`, because it holds your SSH password.
+7. Write and `systemctl enable` the unit — **without starting it**.
+
+::: warning Step 3 removes the install directory
+Anything you put inside `/usr/local/bin/vm_autoscale/` that is not `config.yaml` — a custom webhook script, a patched module — is deleted on every reinstall. Keep such files elsewhere and reference them by absolute path.
+:::
+
+### Reviewing the installer
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-vm-autoscale/main/install.sh -o install.sh
+less install.sh
+sudo bash install.sh
+```
+
+### If `pip3 install` fails
+
+On Proxmox VE 8 and other Debian 12+ systems, pip refuses to install into the system Python:
+
+```
+error: externally-managed-environment
+```
+
+The `apt-get` step above already installed `paramiko`, `PyYAML` and `requests` as system packages, so the service will run regardless — the pip step is redundant there. If you would rather have an isolated environment, use the [virtualenv variant](#running-in-a-virtualenv) below.
+
+## Option B — manual install
+
+```bash
+sudo git clone https://github.com/fabriziosalmi/proxmox-vm-autoscale \
+  /usr/local/bin/vm_autoscale
+cd /usr/local/bin/vm_autoscale
+
+# Dependencies — system packages on Debian/Proxmox
+sudo apt-get install -y python3-paramiko python3-yaml python3-requests
+
+# Lock down the config before you put credentials in it
+sudo chown root:root config.yaml
+sudo chmod 600 config.yaml
+
+# Install the unit shipped in the repository
+sudo cp vm_autoscale.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable vm_autoscale.service
+```
+
+::: tip The repository unit is the better one
+`vm_autoscale.service` in the repository sets `RestartSec=10` and a `Documentation=` link; the unit the installer generates inline does not. On a service configured to `Restart=always`, the missing `RestartSec` means a crash-looping process restarts as fast as systemd allows. Prefer the repository file.
+:::
+
+### Running in a virtualenv
+
+```bash
+sudo python3 -m venv /usr/local/bin/vm_autoscale/.venv
+sudo /usr/local/bin/vm_autoscale/.venv/bin/pip install -r \
+  /usr/local/bin/vm_autoscale/requirements.txt
+```
+
+Then point the unit at it:
+
+```ini
+# /etc/systemd/system/vm_autoscale.service.d/venv.conf
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/vm_autoscale/.venv/bin/python /usr/local/bin/vm_autoscale/autoscale.py
+```
+
+```bash
+sudo systemctl daemon-reload
+```
+
+## Configure before you start
+
+The service is enabled but **not started** after installation, on purpose. Edit the config first:
+
+```bash
+sudo nano /usr/local/bin/vm_autoscale/config.yaml
+```
+
+At minimum you need `proxmox_hosts` and `virtual_machines` filled in with real values. See [your first scaling VM](/guide/quick-start) for the smallest working example, and the [configuration reference](/reference/configuration) for every key.
+
+```bash
+sudo systemctl start vm_autoscale.service
+sudo systemctl status vm_autoscale.service
+```
+
+## Upgrading
+
+Re-running the installer preserves `config.yaml` through the backup/restore cycle. For a manual install:
+
+```bash
+cd /usr/local/bin/vm_autoscale
+sudo cp config.yaml /etc/vm_autoscale/config.yaml.backup
+sudo git pull
+sudo systemctl restart vm_autoscale.service
+```
+
+Read the [changelog](/reference/changelog) before upgrading — behaviour changes are listed there, including one that makes previously-ignored config values start taking effect.
+
+## Uninstalling
+
+```bash
+sudo systemctl stop vm_autoscale.service
+sudo systemctl disable vm_autoscale.service
+sudo rm /etc/systemd/system/vm_autoscale.service
+sudo systemctl daemon-reload
+
+sudo rm -rf /usr/local/bin/vm_autoscale
+sudo rm -rf /etc/vm_autoscale          # contains your config backup
+sudo rm -f  /var/log/vm_autoscale.log
+```
+
+Uninstalling does **not** revert changes made to your VMs. Guests left with `hotplug` and `numa: 1` set by the autoscaler keep those settings, and cores and memory stay wherever the last scaling action left them. Check `qm config <vmid>` on anything that matters.

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -1,0 +1,158 @@
+---
+title: Notifications
+description: Configure Gotify push and SMTP email notifications for Proxmox VM Autoscale, including when they fire, what priority each event carries, and how failures are handled.
+---
+
+# Notifications
+
+Two independent channels: **Gotify** push and **SMTP** email. Enable either, both, or neither. Configuration is validated at startup, so a broken notification setup stops the service immediately rather than failing quietly the first time something interesting happens.
+
+## When notifications fire
+
+| Event | Priority | Sent |
+|---|---|---|
+| CPU or RAM scaled **up** | 7 | Only when the resource actually changed |
+| CPU or RAM scaled **down** | 5 | Only when the resource actually changed |
+| Error processing a VM | 9 | Every occurrence |
+| Unexpected error in the main loop | 10 | Every occurrence, then 60 s pause |
+
+Nothing is sent for a routine poll, and nothing is sent when a threshold is crossed but no change results — hitting `max_cores`, or being inside a cooldown, is silent. Priority is a Gotify concept; the SMTP channel ignores it.
+
+::: tip Error notifications can be a firehose
+A node that has become unreachable produces a priority-9 notification **per VM, per cycle**. Twenty VMs on a 300-second interval is 240 notifications an hour. There is no rate limiting or deduplication. Consider Gotify-side filtering if this matters to you.
+:::
+
+## Gotify
+
+```yaml
+gotify:
+  enabled: true
+  server_url: https://gotify.example.com
+  app_token: AbCdEf123456789
+  priority: 5
+```
+
+| Key | Required | Notes |
+|---|---|---|
+| `enabled` | yes | `false` disables the channel entirely |
+| `server_url` | when enabled | Base URL. A trailing slash is stripped for you |
+| `app_token` | when enabled | **Application** token, not a client token |
+| `priority` | no | Default priority; per-event values above override it |
+
+Messages `POST` to `{server_url}/message` with a 10-second timeout, `Authorization: Bearer <app_token>`, and the title `VM Autoscale Alert`.
+
+If `enabled: true` and either `server_url` or `app_token` is missing, startup fails with:
+
+```
+ConfigurationError: Gotify is enabled but configuration is incomplete
+```
+
+### Getting a token
+
+In Gotify: **Apps → Create Application**, then copy the token shown. Verify it out of band before wiring it in:
+
+```bash
+curl -X POST "https://gotify.example.com/message" \
+  -H "Authorization: Bearer AbCdEf123456789" \
+  -F "title=test" -F "message=hello" -F "priority=5"
+```
+
+## Email (SMTP)
+
+```yaml
+alerts:
+  email_enabled: true
+  email_recipient: ops@example.com
+  smtp_server: smtp.example.com
+  smtp_port: 587
+  smtp_user: autoscale@example.com
+  smtp_password: your_smtp_password
+```
+
+| Key | Required | Notes |
+|---|---|---|
+| `email_enabled` | yes | |
+| `smtp_server` | when enabled | Validated at startup |
+| `smtp_user` | when enabled | Also used as the `From` address |
+| `email_recipient` | when enabled | A string, or a list of strings for several recipients |
+| `smtp_port` | no | Defaults to `587` |
+| `smtp_password` | no | **Leave empty to skip `login()`** — for relays that authenticate by IP |
+
+The service always calls `starttls()`, then authenticates only if `smtp_password` is non-empty.
+
+### Subject lines
+
+The VMID is extracted from the message body with the pattern `VM\s+(\d+)`, producing:
+
+```
+Subject: VM Autoscale Alert for VM 101
+```
+
+Messages with no VMID in them — most main-loop errors — get `VM Autoscale Alert for VM ` with a trailing space. Cosmetic, but it makes subject-based mail filters unreliable for those.
+
+### Several recipients
+
+```yaml
+alerts:
+  email_recipient:
+    - ops@example.com
+    - oncall@example.com
+```
+
+### Local relay
+
+If the host already has a working MTA:
+
+```yaml
+alerts:
+  email_enabled: true
+  smtp_server: localhost
+  smtp_port: 25
+  smtp_user: vm-autoscale@$(hostname -f)
+  smtp_password: ""
+  email_recipient: root@example.com
+```
+
+Note `starttls()` is called unconditionally, so a relay on port 25 must advertise STARTTLS. A plain-text-only local relay will fail.
+
+## Failure handling
+
+Channels are attempted independently and a failure in one does not block the other. Failures are logged, not retried, and never crash the service:
+
+```
+[ERROR] Failed to send Gotify notification: HTTPSConnectionPool(...): Read timed out.
+```
+
+If every configured channel fails, the message itself is written to the log so it is not lost:
+
+```
+[WARNING] Failed to send notification through any channel.
+          Message: Scaled up CPU for VM 101 due to high usage (91.2%).
+          Errors: Failed to send Gotify notification: ...
+```
+
+With no channel enabled at all, you get one warning at startup and then silence:
+
+```
+[WARNING] No notification method is enabled in configuration
+```
+
+## Verifying without waiting for load
+
+Temporarily set an impossible threshold, run the service in the foreground for one cycle, and put it back:
+
+```yaml
+scaling_thresholds:
+  cpu:
+    high: 1
+    low: 0
+```
+
+```bash
+sudo systemctl stop vm_autoscale.service
+sudo python3 /usr/local/bin/vm_autoscale/autoscale.py
+```
+
+## Security notes
+
+`smtp_password` and `app_token` sit in plain text in `config.yaml`. That file must be mode `600` and root-owned — the installer does this, and the [hardening guide](/security/hardening) covers verifying it. Notification bodies contain VMIDs, host names and usage figures; treat your Gotify server and mail path as carrying operational detail about your infrastructure.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -1,0 +1,201 @@
+---
+title: Operations
+description: Day-to-day operation of the Proxmox VM Autoscale service — systemd control, logging, log rotation, monitoring and safe config changes.
+---
+
+# Operations
+
+## Service control
+
+```bash
+sudo systemctl start   vm_autoscale.service
+sudo systemctl stop    vm_autoscale.service
+sudo systemctl restart vm_autoscale.service
+sudo systemctl status  vm_autoscale.service
+
+sudo systemctl enable  vm_autoscale.service   # start at boot
+sudo systemctl disable vm_autoscale.service
+```
+
+The unit sets `Restart=always`, so systemd brings the process back after a crash. The repository's `vm_autoscale.service` also sets `RestartSec=10`; the unit the installer writes inline does not, which on a crash loop means restarting as fast as systemd permits. Check which one you have:
+
+```bash
+systemctl cat vm_autoscale.service | grep -E 'Restart|ExecStart'
+```
+
+::: tip A restart clears cooldown state
+Cooldown timers live in memory. After a restart the first cycle can scale immediately, regardless of when the last change happened. Restarting repeatedly — during a config edit session, say — removes the rate limiting entirely for that period.
+:::
+
+## Logs
+
+Two sinks, both active:
+
+```bash
+tail -f /var/log/vm_autoscale.log        # file, per logging_config.json
+journalctl -u vm_autoscale.service -f    # stdout, captured by systemd
+```
+
+Useful filters:
+
+```bash
+journalctl -u vm_autoscale.service --since "1 hour ago" -p warning
+grep -E 'Scaled (up|down)' /var/log/vm_autoscale.log
+grep -c 'Scaled up' /var/log/vm_autoscale.log
+journalctl -u vm_autoscale.service --since today | grep 'VM 101'
+```
+
+### Log levels
+
+`logging_config.json` takes precedence over the `logging.level` key in `config.yaml` — the latter is only consulted when the JSON file is absent. As shipped, the file handler writes at `DEBUG` and the console at `INFO`, so `/var/log/vm_autoscale.log` is considerably more verbose than `journalctl`.
+
+To quieten the file, edit `logging_config.json`:
+
+```json
+{
+  "handlers": {
+    "file": { "level": "INFO" }
+  }
+}
+```
+
+Restart the service afterwards; logging is configured once at startup.
+
+### Log rotation
+
+Nothing rotates `/var/log/vm_autoscale.log`. At `DEBUG`, with a large fleet, it grows quickly. Add:
+
+```
+# /etc/logrotate.d/vm_autoscale
+/var/log/vm_autoscale.log {
+    weekly
+    rotate 8
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}
+```
+
+`copytruncate` matters: the service holds the file open for its whole lifetime and will keep writing to the rotated inode otherwise.
+
+## Reading the log
+
+| Line | Meaning |
+|---|---|
+| `Host CPU Usage: 12.40%, Host RAM Usage: 61.20%` | Gate 2 passed for this node |
+| `Host pve1 resources maxed out. Skipping scaling.` | Gate 2 blocked; no VM on this node scales this cycle |
+| `VM 101 is not running. Skipping scaling.` | Gate 1 blocked |
+| `VM 101 current usage - CPU: 3.2%, RAM: 41.5%` | The sample the decision is based on |
+| `No CPU scaling required.` | Threshold crossed but a limit was already reached |
+| `Scaled up vCPUs to 3 ... (hotplug applied)` | Live change |
+| `... (requires reboot for full effect)` | Config changed; guest unaffected until reboot |
+| `CPU usage not found in output.` | Metric parse failure — usage falls back to `0.0` |
+| `Error processing VM 101 on host pve1: ...` | Per-VM failure; loop continues |
+
+::: warning `CPU usage not found in output` deserves attention
+It means usage was recorded as `0.0`, which is below every sane `low` threshold, so the next decision is a scale **down**. Left unnoticed, a parsing failure walks every VM down to its minimum. See [troubleshooting](/guide/troubleshooting#usage-always-reads-0).
+:::
+
+## Changing configuration
+
+Config is read once at startup. There is no reload signal.
+
+```bash
+sudo cp /usr/local/bin/vm_autoscale/config.yaml /root/config.yaml.bak
+sudo nano /usr/local/bin/vm_autoscale/config.yaml
+python3 -c "import yaml,sys; yaml.safe_load(open('/usr/local/bin/vm_autoscale/config.yaml'))" \
+  && echo "YAML OK"
+sudo systemctl restart vm_autoscale.service
+journalctl -u vm_autoscale.service -n 30
+```
+
+A malformed config prevents startup:
+
+```
+CRITICAL Failed to start VM Autoscaler: Missing required configuration sections: scaling_limits
+```
+
+Always confirm the service came back up after an edit — `Restart=always` will keep retrying a process that exits immediately on a bad config, and the failure is only visible in the log.
+
+## Pausing scaling
+
+Per VM, without removing its entry:
+
+```yaml
+virtual_machines:
+  - vm_id: 101
+    proxmox_host: pve1
+    scaling_enabled: false
+```
+
+Per resource:
+
+```yaml
+    cpu_scaling: true
+    ram_scaling: false
+```
+
+Everything at once: `systemctl stop vm_autoscale.service`.
+
+## Monitoring the autoscaler itself
+
+The service exposes no metrics endpoint and no health check. Practical options:
+
+**Is it alive?**
+
+```bash
+systemctl is-active vm_autoscale.service
+```
+
+**Is it doing anything?** A healthy service writes at least one host-usage line per cycle. A watchdog on log staleness:
+
+```bash
+#!/bin/bash
+LOG=/var/log/vm_autoscale.log
+AGE=$(( $(date +%s) - $(stat -c %Y "$LOG") ))
+if [ "$AGE" -gt 900 ]; then
+    echo "vm_autoscale log stale: ${AGE}s" >&2
+    exit 1
+fi
+```
+
+**Is it flapping?** Repeated up/down on the same VM means your dead band is too narrow:
+
+```bash
+grep -E 'Scaled (up|down)' /var/log/vm_autoscale.log \
+  | grep 'VM 101' | tail -20
+```
+
+**systemd-native alerting** on failure:
+
+```ini
+# /etc/systemd/system/vm_autoscale.service.d/alert.conf
+[Unit]
+OnFailure=status-email@%n.service
+```
+
+## Backups
+
+Worth keeping:
+
+- `/usr/local/bin/vm_autoscale/config.yaml` — **contains credentials**; encrypt it
+- `/etc/vm_autoscale/config.yaml.backup` — same
+- `/var/log/vm_autoscale/billing/billing_data.json` — if you bill from it
+- `/etc/systemd/system/vm_autoscale.service` and any drop-ins
+
+Never commit `config.yaml` to a repository. `.gitignore` covers `config.local.yaml`, not `config.yaml` — the tracked `config.yaml` is the example, and it is easy to commit a real one over it by accident.
+
+## Running two instances
+
+For different intervals or different host limits per node group:
+
+```bash
+sudo cp -r /usr/local/bin/vm_autoscale /usr/local/bin/vm_autoscale_slow
+sudo cp /etc/systemd/system/vm_autoscale.service \
+        /etc/systemd/system/vm_autoscale_slow.service
+sudo nano /etc/systemd/system/vm_autoscale_slow.service   # point at the new dir
+```
+
+`autoscale.py` hardcodes its config path to `/usr/local/bin/vm_autoscale/config.yaml` in `main()`, so a second instance needs its own copy of the directory rather than just its own config file. Make sure the two instances never manage the same VM: they do not share cooldown state and will fight.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,0 +1,167 @@
+---
+title: Your first scaling VM
+description: The smallest working config.yaml for Proxmox VM Autoscale, plus how to verify that a VM really scales instead of assuming it does.
+---
+
+# Your first scaling VM
+
+The goal here is one VM, scaling, with proof. Get that working before you add the rest of the fleet.
+
+## Step 1 — pick a VM you can disturb
+
+You want a guest where an extra core appearing or a gigabyte disappearing will not ruin anyone's afternoon. Note its VMID (`qm list`) and the node it lives on.
+
+## Step 2 — prepare the guest
+
+Live scaling needs both hotplug and NUMA. You can set them by hand once:
+
+```bash
+qm set 101 -hotplug cpu,memory,network,disk,usb
+qm set 101 -numa 1
+```
+
+Then **reboot the guest**. NUMA is a machine-topology change; it does not apply to a running VM. You can also let the service do this for you with `auto_configure_hotplug: true` — see [hotplug and NUMA](/guide/hotplug) for the trade-offs.
+
+Verify:
+
+```bash
+qm config 101 | grep -E 'hotplug|numa|cores|vcpus|memory|balloon'
+```
+
+## Step 3 — minimal config
+
+Replace the shipped `config.yaml` with something this small while you are testing:
+
+```yaml
+# /usr/local/bin/vm_autoscale/config.yaml
+
+scaling_thresholds:
+  cpu:
+    high: 80
+    low: 20
+  ram:
+    high: 85
+    low: 25
+
+scaling_limits:
+  min_cores: 1
+  max_cores: 4
+  min_ram_mb: 1024      # NUMA misbehaves below 1 GB — do not lower this
+  max_ram_mb: 8192
+
+check_interval: 60      # short, only while you are testing
+scale_cooldown: 120     # short, only while you are testing
+
+proxmox_hosts:
+  - name: pve1
+    host: 192.168.1.10
+    ssh_user: root
+    ssh_key: /root/.ssh/id_rsa
+    ssh_port: 22
+
+virtual_machines:
+  - vm_id: 101
+    proxmox_host: pve1
+    scaling_enabled: true
+    cpu_scaling: true
+    ram_scaling: true
+
+host_limits:
+  max_host_cpu_percent: 90
+  max_host_ram_percent: 90
+
+auto_configure_hotplug: false   # you did it by hand in step 2
+
+logging:
+  level: DEBUG                  # while testing
+  log_file: /var/log/vm_autoscale.log
+```
+
+::: warning `ssh_key` must be an RSA key
+Key authentication currently loads the file as an RSA key specifically. An Ed25519 or ECDSA key will fail to load and the connection will fall back to failing. See [known limitations](/reference/limitations#only-rsa-ssh-keys-are-supported). Use a password, or generate an RSA key, until that is fixed.
+:::
+
+`proxmox_host` in each VM entry must match a `name` in `proxmox_hosts` exactly — a mismatch means the VM is silently never processed.
+
+## Step 4 — run it in the foreground first
+
+Do not start the systemd unit yet. Run it by hand so you can see everything:
+
+```bash
+sudo systemctl stop vm_autoscale.service
+sudo python3 /usr/local/bin/vm_autoscale/autoscale.py
+```
+
+Within one `check_interval` you should see lines like:
+
+```
+[INFO] Host CPU Usage: 12.40%, Host RAM Usage: 61.20%
+[INFO] VM 101 is running.
+[INFO] VM 101 current usage - CPU: 3.2%, RAM: 41.5%
+[INFO] No CPU scaling required.
+```
+
+If instead you see `Error processing VM 101 on host pve1: ...`, stop and fix that before going further — [troubleshooting](/guide/troubleshooting) covers the usual causes.
+
+## Step 5 — force a scaling event
+
+The quickest honest test is to move the threshold rather than manufacture load. Temporarily set:
+
+```yaml
+scaling_thresholds:
+  cpu:
+    high: 1     # anything above 1% triggers a scale up
+    low: 0
+```
+
+Restart the foreground process. You should get:
+
+```
+[INFO] Scaled up vCPUs to 3 for VM 101 (hotplug applied).
+```
+
+Confirm on the node that it actually happened — the log line reports the command was sent, not that the guest accepted it:
+
+```bash
+qm config 101 | grep -E 'cores|vcpus'
+```
+
+And inside the guest:
+
+```bash
+nproc
+lscpu | grep '^CPU(s):'
+```
+
+::: tip Generating real load instead
+If you would rather test with genuine pressure, `stress-ng --cpu $(nproc) --timeout 300s` inside the guest works. Remember the service samples once per `check_interval` — the load has to still be running when the poll happens.
+:::
+
+Now restore your real thresholds.
+
+## Step 6 — watch it come back down
+
+Leave the guest idle for longer than `scale_cooldown` and you should see the reverse:
+
+```
+[INFO] Scaled down vCPUs to 2 for VM 101 (hotplug applied).
+```
+
+If it scales up but never down, the usual cause is that idle CPU sits above your `low` threshold — a guest doing nothing is rarely at 0%. Widen the dead band.
+
+## Step 7 — hand it to systemd
+
+```bash
+sudo nano /usr/local/bin/vm_autoscale/config.yaml   # restore check_interval: 300, level: INFO
+sudo systemctl start vm_autoscale.service
+sudo systemctl status vm_autoscale.service
+journalctl -u vm_autoscale.service -f
+```
+
+## Step 8 — add the rest
+
+Add hosts and VMs one at a time, checking the log after each. Things to keep in mind as the list grows:
+
+- Hosts are processed **sequentially**, and each VM opens and closes its own SSH connection. With many VMs a cycle can take longer than `check_interval`, at which point cycles simply run back-to-back.
+- Set `scaling_enabled: false` rather than deleting an entry when you want to park a VM — it documents the intent.
+- Turn on [notifications](/guide/notifications) once you stop watching the log.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,242 @@
+---
+title: Troubleshooting
+description: Diagnose the common failure modes of Proxmox VM Autoscale — service won't start, SSH failures, VMs that never scale, usage stuck at zero, and changes that don't reach the guest.
+---
+
+# Troubleshooting
+
+Start here, in order: is the service running, is it connecting, is it reading usage, is it deciding to scale, does the change reach the guest.
+
+```bash
+systemctl is-active vm_autoscale.service
+journalctl -u vm_autoscale.service -n 50 --no-pager
+tail -50 /var/log/vm_autoscale.log
+```
+
+## The service will not start
+
+```bash
+journalctl -u vm_autoscale.service -n 50 --no-pager | grep -i critical
+```
+
+### `Missing required configuration sections: ...`
+
+One of `scaling_thresholds`, `scaling_limits`, `proxmox_hosts`, `virtual_machines` is absent. All four are mandatory even if you are not using them meaningfully.
+
+### `Configuration file not found at /usr/local/bin/vm_autoscale/config.yaml`
+
+The path is hardcoded. If you installed elsewhere, either symlink it or edit `main()` in `autoscale.py`.
+
+### `Gotify is enabled but configuration is incomplete`
+
+`gotify.enabled: true` with `server_url` or `app_token` missing. Same shape of error for email:
+
+```
+Email alerts are enabled but missing configuration: smtp_server, smtp_user
+```
+
+### YAML syntax errors
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('/usr/local/bin/vm_autoscale/config.yaml'))"
+```
+
+Tabs are the usual culprit — YAML forbids them for indentation.
+
+### Permission denied writing the log
+
+The service needs write access to `logging_config.json`'s `filename` (default `/var/log/vm_autoscale.log`). Running as root this is fine; if you changed `User=`, it is probably not.
+
+## SSH failures
+
+### `Authentication failed for 192.168.1.10`
+
+Not retried — credentials are wrong, or the key was rejected. Test the exact same path by hand:
+
+```bash
+ssh -p 22 -i /root/.ssh/id_rsa root@192.168.1.10 'qm list'
+```
+
+### Key authentication fails but the key is fine
+
+**Only RSA keys are supported.** The key file is loaded specifically as an RSA key, so an Ed25519 or ECDSA key fails to load however valid it is. This is the single most common cause of "my key works from the shell but not from the service".
+
+```bash
+head -1 /root/.ssh/id_ed25519    # OPENSSH PRIVATE KEY → will not work
+ssh-keygen -t rsa -b 4096 -f /root/.ssh/vm_autoscale_rsa -N ""
+ssh-copy-id -i /root/.ssh/vm_autoscale_rsa.pub root@192.168.1.10
+```
+
+Then point `ssh_key` at the new private key. See [known limitations](/reference/limitations#only-rsa-ssh-keys-are-supported).
+
+### `Failed to connect to 192.168.1.10 after 5 attempts`
+
+Five attempts with exponential backoff (1, 2, 4, 8, 16 s) — roughly 31 seconds before giving up. Network, firewall, or `sshd` not listening on `ssh_port`.
+
+```bash
+nc -vz 192.168.1.10 22
+```
+
+### Both password and key configured
+
+If `ssh_password` is set it wins; `ssh_key` is ignored entirely. Remove or blank the password to force key auth. The shipped example config has **both** filled in with placeholders, so leaving it half-edited means the placeholder password is what gets used.
+
+### Too many SSH sessions
+
+A connection is opened and closed per VM per cycle. With many VMs and a short `check_interval`, you can hit `MaxStartups` or `MaxSessions` on the node. Raise `check_interval`, or raise the limits in `/etc/ssh/sshd_config`.
+
+## A VM never scales
+
+Work down this list:
+
+**1. Is it enabled?**
+
+```yaml
+scaling_enabled: true
+cpu_scaling: true
+ram_scaling: true
+```
+
+**2. Does `proxmox_host` match a host `name` exactly?** A mismatch means the VM entry is never reached — and there is no warning for it. Case and whitespace matter.
+
+**3. Is the guest running?**
+
+```
+[INFO] VM 101 is not running. Skipping scaling.
+```
+
+**4. Is the host blocking it?**
+
+```
+[WARNING] Host pve1 resources maxed out. Skipping scaling.
+```
+
+Raise `host_limits`, or accept that the node is genuinely full. On ZFS hosts, ARC counts as used memory — check `arc_summary` before concluding the ceiling is real.
+
+**5. Is usage actually crossing a threshold?**
+
+```
+[INFO] VM 101 current usage - CPU: 45.2%, RAM: 62.1%
+```
+
+45% is inside a 20–80 dead band. Nothing is wrong.
+
+**6. Is it already at a limit?**
+
+```
+[INFO] No CPU scaling required.
+```
+
+Check `qm config 101` against your `scaling_limits`.
+
+**7. Is it in cooldown?** No log line is emitted for this. Look at the timestamp of the last `Scaled ...` line for that VM and compare against `scale_cooldown`.
+
+## Usage always reads 0%
+
+```
+[WARNING] CPU usage not found in output.
+[WARNING] RAM memory values not found in output.
+```
+
+Usage is scraped from `pvesh`'s human-readable table, and the format is version-sensitive. Run the exact command on the node:
+
+```bash
+pvesh get /cluster/resources | grep 'qemu/101' | awk -F '│' '{print $6, $15, $16}'
+```
+
+You want something like `3.17% 5.00 GiB 3.82 GiB`. Empty output or wrong columns means the format on your Proxmox version does not match what the parser expects.
+
+::: danger This failure mode scales VMs down
+`0.0` is below every reasonable `low` threshold, so a parse failure reads as "completely idle" and every affected VM walks down to its minimum, one step per cycle. If you see these warnings, stop the service before it finishes.
+:::
+
+Also check the `grep` is not matching the wrong guest — `grep 'qemu/101'` matches `qemu/1010` too. If you have both, the parse silently reads the wrong row.
+
+## The change does not reach the guest
+
+### RAM changes but the guest does not see it
+
+```
+[WARNING] VM 101 has memory hotplug enabled but NUMA is disabled.
+          Memory changes will require a reboot.
+```
+
+Enable NUMA and **reboot the guest** — NUMA is a topology change and does not apply live.
+
+If both are enabled and it still does not take effect, the balloon driver is missing or wedged inside the guest:
+
+```bash
+# inside the guest
+lsmod | grep virtio_balloon
+dmesg | grep -i balloon
+```
+
+### CPU count does not change inside the guest
+
+Scaling `cores` requires a reboot; only `vcpus` is live. Look at which one the log said it changed:
+
+```
+[WARNING] VM 101: Increased cores to 5 (requires reboot for full effect)
+          and vCPUs to 5 (hotplug applied).
+```
+
+Removing a vCPU is also unreliable — Windows guests in particular often refuse. QEMU accepts the command and the service reports success either way.
+
+### `qm set` fails but the log says it succeeded
+
+Command results are not checked for a non-zero exit status before the success line is written. Confirm on the node:
+
+```bash
+qm config 101 | grep -E 'cores|vcpus|memory|balloon'
+```
+
+## It scales up and down constantly
+
+The dead band between `low` and `high` is too narrow for how the workload actually moves.
+
+```yaml
+scaling_thresholds:
+  cpu:
+    high: 85
+    low: 15     # a wide band absorbs normal variation
+```
+
+Also raise `scale_cooldown`. Remember the effective interval is `max(check_interval, scale_cooldown)`, so a cooldown below the poll interval does nothing.
+
+Repeated `systemctl restart` also defeats the cooldown, since the timers are in memory.
+
+## Notifications do not arrive
+
+```bash
+grep -i notification /var/log/vm_autoscale.log
+```
+
+`Failed to send notification through any channel` includes the original message and the per-channel errors. Test Gotify independently:
+
+```bash
+curl -X POST "https://gotify.example.com/message" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -F "title=test" -F "message=test"
+```
+
+For SMTP, remember `starttls()` is always called — a relay that does not advertise STARTTLS will fail. Leave `smtp_password` empty to skip authentication on an IP-authenticated relay.
+
+Also: notifications only fire on **actual changes**. A threshold crossed while at a limit or in cooldown sends nothing, by design.
+
+## Billing produces no CSV
+
+Expected. Report generation is not wired into the service — only spec recording is. See [billing](/guide/billing#what-is-automatic-and-what-is-not) for the script that generates one.
+
+## Getting help
+
+Before opening an issue, collect:
+
+```bash
+python3 --version
+pveversion
+systemctl status vm_autoscale.service --no-pager
+journalctl -u vm_autoscale.service -n 100 --no-pager
+qm config <vmid>
+```
+
+Then [open an issue](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/new/choose) with your config **with every credential removed** — `ssh_password`, `smtp_password`, `app_token`, host addresses if they are sensitive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,76 @@
+---
+layout: home
+title: Proxmox VM Autoscale
+titleTemplate: Right-size Proxmox VMs automatically
+description: Threshold-based CPU and RAM autoscaling for Proxmox VE virtual machines — a systemd service that drives qm over SSH, with hotplug support, host safety limits and Gotify/SMTP notifications.
+
+hero:
+  name: Proxmox VM Autoscale
+  text: Right-size your VMs while they run
+  tagline: A small systemd service that watches CPU and RAM on your Proxmox VE guests and adjusts cores and memory through qm over SSH — with hotplug, host safety limits and notifications.
+  image:
+    src: /favicon.svg
+    alt: Proxmox VM Autoscale
+  actions:
+    - theme: brand
+      text: Get started
+      link: /guide/
+    - theme: alt
+      text: Installation
+      link: /guide/installation
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/fabriziosalmi/proxmox-vm-autoscale
+
+features:
+  - icon: 📈
+    title: Threshold-based scaling
+    details: Scale cores and RAM up past a high-water mark and back down below a low one. One step per decision, bounded by limits you set, rate-limited by a per-resource cooldown.
+    link: /guide/how-it-works
+    linkText: How decisions are made
+  - icon: ⚡
+    title: Live changes where possible
+    details: With hotplug and NUMA enabled, vCPU and balloon memory changes apply to a running guest. Where they cannot, the service says so in the log instead of pretending.
+    link: /guide/hotplug
+    linkText: Hotplug and NUMA
+  - icon: 🛡️
+    title: Host safety first
+    details: Every scaling decision is gated on the host itself having headroom. If the node is above your CPU or RAM ceiling, nothing scales up on it.
+    link: /guide/host-limits
+    linkText: Host safety limits
+  - icon: 🔔
+    title: Notifications that mean something
+    details: Gotify push and SMTP email on real scaling actions and on errors — not on every poll. Both optional, both independent.
+    link: /guide/notifications
+    linkText: Configure notifications
+  - icon: 🧾
+    title: Usage tracking for hosters
+    details: Records every spec change with a timestamp and turns a period into a costed CSV report. Useful if you bill customers for what they actually consumed.
+    link: /guide/billing
+    linkText: Billing tracking
+  - icon: 🔐
+    title: Root SSH, treated seriously
+    details: The service holds credentials for root on your hypervisors. The security section documents exactly what that exposes and how to narrow it.
+    link: /security/
+    linkText: Threat model
+---
+
+## Is this for you?
+
+This service suits a homelab or a small fleet where a handful of VMs have **bursty, uncorrelated load** and you would rather not over-provision all of them for the peak. It reads usage from the hypervisor, compares it against thresholds you set, and moves one step at a time.
+
+It is deliberately not a cluster scheduler. It does not migrate guests, does not create or destroy VMs, and does not model future load — see [what it does not do](/guide/#what-it-does-not-do) before you build anything on top of it.
+
+```bash
+# Install on a Proxmox node (or any Linux host with SSH access to one)
+bash <(curl -s https://raw.githubusercontent.com/fabriziosalmi/proxmox-vm-autoscale/main/install.sh)
+
+# Point it at your hosts and VMs, then start it
+sudo nano /usr/local/bin/vm_autoscale/config.yaml
+sudo systemctl start vm_autoscale.service
+journalctl -u vm_autoscale.service -f
+```
+
+::: warning Read this before running it in production
+The service authenticates to your Proxmox hosts as **root** and issues `qm set` against live guests. Read the [threat model](/security/) and the [known limitations](/reference/limitations) first. There is no dry-run mode.
+:::

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,78 @@
+---
+title: Privacy
+description: What data this documentation site collects, what the Proxmox VM Autoscale software itself transmits, and where your data goes.
+---
+
+# Privacy
+
+Two separate questions: what this website does, and what the software does. Both answers are short.
+
+## This website
+
+This site is static HTML hosted on **GitHub Pages**. It is built from the repository by GitHub Actions and served by GitHub.
+
+### What the site itself does
+
+- **No analytics.** No Google Analytics, no Plausible, no Fathom, no pixel, no tag manager.
+- **No cookies.** The site sets none.
+- **No third-party embeds.** No YouTube, no Disqus, no chat widget, no social buttons.
+- **No fonts loaded from a third party.** Typography uses the fonts already on your device.
+- **No forms.** Nothing on this site accepts input, so there is nothing to submit.
+- **Search runs in your browser.** The search index is a static file downloaded with the page; your queries are not sent anywhere.
+- **Theme preference** (light/dark) is stored in your browser's `localStorage`. It stays on your device and is never transmitted.
+
+### What GitHub does
+
+GitHub Pages serves the site, and GitHub logs requests as part of operating that service. GitHub's own documentation states it collects visitors' IP addresses for security and to keep the service running, retaining them for up to 14 days.
+
+That processing is GitHub's, not ours, and we neither receive nor have access to those logs. See the [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement) and [GitHub Pages data collection](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages#data-collection).
+
+### External links
+
+Pages link to GitHub, the Proxmox documentation, and a handful of other sites. Following one takes you to a third party with its own policy.
+
+### The Open Graph image
+
+Social previews reference an image hosted by GitHub (`repository-images.githubusercontent.com`). It loads only when a platform generates a preview card, not when you read the site.
+
+## The software
+
+Proxmox VM Autoscale runs on your infrastructure. It has no telemetry, no update check, no crash reporting, and no call home of any kind.
+
+### What it connects to
+
+Only what you configure:
+
+| Destination | When | Contents |
+|---|---|---|
+| Your Proxmox nodes, over SSH | Every cycle | `qm` and `pvesh` commands |
+| Your Gotify server, over HTTPS | On scaling actions and errors, if enabled | Notification text: VMID, host name, usage percentage |
+| Your SMTP relay | On scaling actions and errors, if enabled | The same text, as email |
+| Your `webhook_url` | On billing report generation, if configured | The billing report as JSON |
+
+Every one of those is a host **you** name in `config.yaml`. The project operates none of them and receives nothing.
+
+### What it stores locally
+
+| Data | Location | Contents |
+|---|---|---|
+| Log | `/var/log/vm_autoscale.log` | Host names, VMIDs, usage figures, actions taken |
+| Billing state | `billing_data.json` in `csv_output_dir` | Timestamped CPU and RAM specs per VM |
+| Billing reports | CSV in `csv_output_dir` | Costed period summaries |
+| Configuration | `config.yaml` | **Your credentials, in plain text** |
+
+All of it stays on your machine. Nothing is uploaded, and there is no retention policy beyond what you set — the log does not rotate on its own and the billing file is never pruned. See [operations](/guide/operations#log-rotation).
+
+### If you run it for customers
+
+The billing data records how much CPU and RAM each VM held over time, which for a hosting provider is customer information. Your obligations under GDPR or equivalent law are yours, not this project's: it is software you run, not a service anyone operates for you.
+
+## Contact
+
+Questions about this page, or about the project's handling of data: **fabrizio.salmi@gmail.com**.
+
+Security issues: [responsible disclosure](/security/disclosure), not email to the address above without reading that page first.
+
+---
+
+*Last reviewed: September 2026. Changes to this page are tracked in the [repository history](https://github.com/fabriziosalmi/proxmox-vm-autoscale/commits/main/docs/privacy.md).*

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,13 @@
+# Security contact for Proxmox VM Autoscale
+# https://github.com/fabriziosalmi/proxmox-vm-autoscale
+#
+# Note: RFC 9116 places this file at the root of a domain. This project is
+# served from a path on github.io, so this copy is non-canonical and is
+# published for completeness. The contact below is authoritative.
+
+Contact: mailto:fabrizio.salmi@gmail.com
+Expires: 2027-09-05T00:00:00.000Z
+Preferred-Languages: en, it
+Canonical: https://fabriziosalmi.github.io/proxmox-vm-autoscale/.well-known/security.txt
+Policy: https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/disclosure.html
+Acknowledgments: https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/disclosure.html#what-to-expect

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Proxmox VM Autoscale">
+  <rect width="64" height="64" rx="12" fill="#e57000"/>
+  <g fill="none" stroke="#fff" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="14" y="34" width="12" height="16"/>
+    <rect x="30" y="24" width="12" height="26"/>
+    <path d="M46 22V12h-10"/>
+    <path d="M36 22 52 6" stroke-width="5"/>
+  </g>
+</svg>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,66 @@
+# Proxmox VM Autoscale
+
+> A systemd service that automatically adjusts CPU cores and RAM of Proxmox VE
+> virtual machines based on real-time usage. It connects to Proxmox nodes over
+> SSH and drives the standard `qm` and `pvesh` command-line tools; there is no
+> agent inside the guests and no Proxmox API token. Written in Python, MIT
+> licensed, maintained by Fabrizio Salmi.
+
+Scope: vertical scaling only — it resizes VMs you list explicitly. It never
+creates, clones, destroys or migrates a VM, does not handle LXC containers, and
+does not scale disk or network. Decisions come from a single instantaneous
+sample per polling cycle, compared against global thresholds; one step (1 core
+or 512 MB) per resource per cycle, bounded by configured limits and a
+per-resource cooldown. There is no dry-run mode.
+
+Key constraints a reader should know: the service authenticates to Proxmox
+nodes as root and holds those credentials in plain text in config.yaml; SSH
+host keys are accepted automatically without pinning; guest metrics are parsed
+from a human-readable `pvesh` table, and a parse failure reads as 0% usage and
+scales VMs down. Only RSA SSH keys load. Per-VM thresholds shown in the example
+config are not read by the code. Billing records spec changes automatically but
+does not generate reports without being called explicitly.
+
+## Getting started
+
+- [Introduction](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/index.html): what it does, what it deliberately does not do, requirements and assumptions
+- [Installation](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/installation.html): installer script and manual install, what lands where, upgrading and uninstalling
+- [Your first scaling VM](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/quick-start.html): minimal config.yaml and how to verify a VM really scales
+
+## Core concepts
+
+- [How scaling decisions are made](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/how-it-works.html): the cycle, both gates, thresholds, fixed step sizes, limits, per-resource cooldowns
+- [Hotplug and NUMA](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/hotplug.html): what applies live versus what needs a guest reboot, and what auto_configure_hotplug changes
+- [Host safety limits](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/host-limits.html): how host_limits gates every decision, including scale-down
+
+## Features
+
+- [Notifications](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/notifications.html): Gotify and SMTP configuration, event priorities, failure handling
+- [Billing tracking](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/billing.html): spec-change recording, what is automatic and what is not, generating a costed CSV
+
+## Running it
+
+- [Operations](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/operations.html): systemd control, log levels and rotation, config changes, monitoring
+- [Troubleshooting](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/troubleshooting.html): startup failures, SSH problems, VMs that never scale, usage stuck at 0%
+- [FAQ](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/faq.html): scope, setup, behaviour, tuning, safety, production readiness
+
+## Reference
+
+- [Configuration reference](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/configuration.html): every config.yaml key, type, default and actual effect
+- [Architecture](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/architecture.html): modules, control flow, threading, state, error handling, extension points
+- [Python modules](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/modules.html): classes and public methods across the five source files
+- [Known limitations](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/limitations.html): complete catalogue of known defects and design constraints
+- [Changelog](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/changelog.html): release history, including tags published out of chronological order
+
+## Security
+
+- [Threat model](https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/index.html): assets, attacker positions, design-level exposures, what is not a risk
+- [Hardening guide](https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/hardening.html): file permissions, dedicated SSH key, systemd confinement, egress filtering
+- [Reporting a vulnerability](https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/disclosure.html): private disclosure process, scope, response timeline
+
+## Optional
+
+- [Contributing](https://fabriziosalmi.github.io/proxmox-vm-autoscale/contributing.html): development setup, tests, code style, areas that need work
+- [Privacy](https://fabriziosalmi.github.io/proxmox-vm-autoscale/privacy.html): no analytics on this site, no telemetry in the software
+- [Source repository](https://github.com/fabriziosalmi/proxmox-vm-autoscale)
+- [LXC equivalent](https://github.com/fabriziosalmi/proxmox-lxc-autoscale): sibling project for containers

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,5 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+Sitemap: https://fabriziosalmi.github.io/proxmox-vm-autoscale/sitemap.xml

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,0 +1,165 @@
+---
+title: Architecture
+description: How Proxmox VM Autoscale is put together — components, control flow, threading model, state, and the extension points that exist.
+---
+
+# Architecture
+
+Five Python modules, roughly 1,500 lines, no framework, no database, no network listener. The whole service is one blocking loop over SSH.
+
+## Components
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ autoscale.py                                                 │
+│                                                              │
+│  VMAutoscaler ......... config, main loop, decision routing  │
+│  NotificationManager .. Gotify + SMTP fan-out                │
+│  ConfigurationError ... raised on invalid startup config     │
+└───────┬──────────────────────┬───────────────────┬───────────┘
+        │                      │                   │
+        ▼                      ▼                   ▼
+┌───────────────┐   ┌──────────────────┐   ┌──────────────────┐
+│ vm_manager.py │   │ host_resource_   │   │ billing_tracker  │
+│               │   │ checker.py       │   │ .py              │
+│ VMResource-   │   │                  │   │                  │
+│ Manager       │   │ HostResource-    │   │ BillingTracker   │
+│               │   │ Checker          │   │ SpecChangeRecord │
+│ per-VM state, │   │                  │   │ StateChangeRec.  │
+│ limits,       │   │ node CPU/RAM     │   │ BillingReport    │
+│ cooldowns,    │   │ gate             │   │                  │
+│ qm commands   │   │                  │   │ JSON state, CSV  │
+└───────┬───────┘   └────────┬─────────┘   └──────────────────┘
+        │                    │
+        └────────┬───────────┘
+                 ▼
+        ┌──────────────────┐
+        │ ssh_utils.py     │
+        │                  │
+        │ SSHClient        │
+        │ connect / retry  │
+        │ exec / close     │
+        └────────┬─────────┘
+                 │  SSH
+                 ▼
+        ┌──────────────────┐
+        │ Proxmox VE node  │
+        │ qm  ·  pvesh     │
+        └──────────────────┘
+```
+
+## Control flow
+
+```
+main()
+└─ VMAutoscaler(config_path, logging_config_path)
+   ├─ _load_config()          validate the four required sections
+   ├─ _setup_logging()        logging_config.json wins over config.yaml
+   ├─ NotificationManager()   validate channels, fail fast
+   └─ BillingTracker()        only when billing.enabled
+
+VMAutoscaler.run()
+└─ while True:
+   └─ for host in proxmox_hosts:
+      └─ for vm in virtual_machines where vm.proxmox_host == host.name
+                                     and vm.scaling_enabled:
+         └─ process_vm(host, vm)
+            ├─ SSHClient(...).connect()
+            ├─ _get_vm_manager(ssh, vm_id)    cached per VM
+            ├─ vm_manager.is_vm_running()          → gate 1
+            ├─ HostResourceChecker(...).check()    → gate 2
+            ├─ vm_manager.get_resource_usage()
+            ├─ _handle_cpu_scaling()   if cpu_scaling
+            ├─ _handle_ram_scaling()   if ram_scaling
+            └─ ssh_client.close()      always, in finally
+      sleep(check_interval)
+```
+
+## Per-module notes
+
+### `autoscale.py`
+
+`VMAutoscaler` owns configuration, the loop and the routing of decisions; it does not talk to Proxmox itself. `_handle_cpu_scaling` and `_handle_ram_scaling` compare a usage figure against thresholds and call into the VM manager, then notify and record billing when the manager reports an actual change.
+
+`_get_vm_manager` caches one `VMResourceManager` per VMID for the lifetime of the process and rebinds it to each cycle's SSH client. That cache is what makes `scale_cooldown` meaningful across cycles and what keeps hotplug auto-configuration to a single check per VM.
+
+`NotificationManager` validates its configuration in the constructor, so a broken notification setup stops the service at startup rather than at the first interesting event.
+
+### `vm_manager.py`
+
+`VMResourceManager` is the only module that mutates anything. It holds:
+
+- `scale_cooldown` and one timestamp per resource (`cpu`, `ram`)
+- a `threading.Lock` guarding those timestamps
+- the config, for limit lookups
+
+`can_scale(resource)` is a pure read; `_mark_scaled(resource)` starts a timer and is called only after a command has been issued. Limits resolve through `_scaling_limit`, which prefers the `scaling_limits` section and falls back to legacy flat keys.
+
+### `ssh_utils.py`
+
+`SSHClient` wraps Paramiko. Connection: up to five attempts with exponential backoff, except authentication failures which raise immediately. Command execution: up to five attempts, closing and reconnecting between them, returning `(stdout, stderr, exit_status)`.
+
+It is also a context manager, though `process_vm` uses explicit `connect()` / `close()` in a `try`/`finally` instead.
+
+### `host_resource_checker.py`
+
+One method. Runs `pvesh get /nodes/$(hostname)/status --output-format json`, parses it, compares against the two ceilings, returns a boolean. Raises on JSON errors and missing fields — which surfaces as a per-VM `Error processing VM ...` rather than stopping the service.
+
+### `billing_tracker.py`
+
+Three dataclasses and a tracker. State is a single JSON file rewritten in full on every record. Reporting — period calculation, CSV export, webhooks — is complete API surface that the service does not currently call.
+
+## Threading and concurrency
+
+Effectively single-threaded. `threading.Lock` in `VMResourceManager` guards the cooldown timestamps, but nothing spawns a thread: hosts and VMs are processed sequentially, and each SSH command blocks.
+
+Consequences:
+
+- A slow or unreachable node stalls every VM behind it in the cycle. Five connection attempts with backoff is ~31 seconds; command retries add more.
+- Total cycle time grows linearly with the number of VMs.
+- `check_interval` is a floor on the gap between cycles, not a period.
+
+## State
+
+| State | Lives in | Survives a restart? |
+|---|---|---|
+| Configuration | `config.yaml`, read once | n/a |
+| Cooldown timestamps | Process memory | **No** |
+| Cached VM managers | Process memory | No |
+| SSH connections | Per VM, per cycle | No |
+| Billing spec changes | `billing_data.json` | Yes |
+| Logs | `/var/log/vm_autoscale.log` + journal | Yes |
+
+The only durable state the service writes is the billing file.
+
+## Error handling
+
+Three layers:
+
+1. **Per operation** — SSH connect and exec retry with backoff. Metric parse failures return `0.0` rather than raising, which is the source of the [silent scale-down](/reference/limitations#metric-parsing-is-format-sensitive) hazard.
+2. **Per VM** — `process_vm` wraps everything in `try`/`except`. A failure is logged, notified at priority 9, and the loop moves to the next VM. CPU and RAM scaling are additionally wrapped separately, so a CPU failure does not prevent the RAM evaluation.
+3. **Per cycle** — the main loop catches anything unexpected, notifies at priority 10, sleeps 60 seconds and continues. `KeyboardInterrupt` exits cleanly.
+
+The process only exits on a startup failure (`sys.exit(1)`) or `SIGINT`.
+
+## Extension points
+
+Realistic places to add behaviour without restructuring:
+
+| Goal | Where |
+|---|---|
+| A new notification channel | Add a `send_*` method to `NotificationManager` and a branch in `send_notification` |
+| Different scaling arithmetic | `VMResourceManager.scale_cpu` / `scale_ram` |
+| More metrics | `get_resource_usage` and the `_parse_*` helpers |
+| Per-VM thresholds | `_handle_cpu_scaling` / `_handle_ram_scaling` already receive the VM dict's siblings; the plumbing to pass it is small |
+| Scheduled billing reports | Call `BillingTracker.generate_period_report` from the main loop on a period boundary |
+
+## Tests
+
+`tests/` holds 114 unit tests across five files, run with `pytest`. They use mocked SSH clients throughout — there is no integration test against a real Proxmox node, so anything depending on actual `pvesh` output format is unverified by CI.
+
+```bash
+python3 -m pytest tests/ -q
+```
+
+CI runs the suite on Python 3.9–3.12 and `shellcheck -S warning` on `install.sh`.

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,0 +1,62 @@
+---
+title: Changelog
+description: Release history for Proxmox VM Autoscale, including behaviour changes that affect existing installations.
+---
+
+# Changelog
+
+Maintained in [`CHANGELOG.md`](https://github.com/fabriziosalmi/proxmox-vm-autoscale/blob/main/CHANGELOG.md), following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+::: warning Tags are not in chronological order
+`v1.2.0` was published in December 2025 and `v0.1.1` in April 2026 — and **`v0.1.1` is the current release**. The version numbers do not reflect ordering. Go by [the releases page](https://github.com/fabriziosalmi/proxmox-vm-autoscale/releases) rather than by the highest number.
+:::
+
+## Unreleased
+
+### Fixed
+
+- **`scaling_limits` from `config.yaml` is now actually enforced.** The validator required the section, but the code looked its values up as flat top-level keys under names that do not exist (`max_ram`/`min_ram` instead of `max_ram_mb`/`min_ram_mb`). Every installation silently ran on the hardcoded defaults 1–8 cores and 512–16384 MB, so the documented `min_ram_mb: 1024` — needed because NUMA misbehaves below 1 GB — had no effect. Flat keys remain accepted as a fallback for older configs.
+
+  ::: danger Upgrade note
+  Your configured limits are about to take effect for the first time. Re-read `scaling_limits` before upgrading, particularly if you set a `max_cores` above 8 or a `min_ram_mb` above 512 and have been running against the defaults without realising.
+  :::
+
+- **CPU and RAM now have independent cooldowns** ([#30](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/30)). A single shared timestamp meant any CPU threshold breach suppressed RAM scaling for the same cycle. The cooldown is also consumed only when a scaling command is actually issued — previously the *check* consumed it, so a VM already at its limit was rate-limited for doing nothing.
+
+- **`scale_cooldown` now applies between polling cycles.** `VMResourceManager` was rebuilt on every iteration of the main loop, resetting the cooldown to zero; the effective interval was `check_interval`, not `scale_cooldown`. Managers are now cached per VM and rebound to each cycle's SSH connection. Side effect: hotplug auto-configuration runs once per VM instead of two extra `qm config` calls per VM per cycle.
+
+### Security
+
+- **`install.sh` no longer leaves `config.yaml` world-readable.** A recursive `chmod 755` over the install directory applied to the config file too — the file holding the Proxmox root SSH password and SMTP credentials in plain text. The config and its backup are now root-owned mode `600`, and the backup directory mode `700`, matching what `SECURITY.md` already prescribed.
+
+### Added
+
+- `tests/test_scaling_limits_and_cooldown.py`: 20 regression tests covering limit resolution (including one asserting the limits shipped in `config.yaml` are the ones enforced), independent per-resource cooldowns, and manager reuse across cycles.
+- This documentation site.
+
+## [0.1.1] — 2026-04-27
+
+### Fixed
+
+- **Host RAM usage now matches the Proxmox web UI** ([#38](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/38)). RAM was computed from `free + cached`, ignoring reclaimable buff/cache, so a host with a warm page cache reported ~90% usage when the real figure was ~66% — and all scaling on it was suppressed. It now reads the `used` field from `pvesh` directly.
+
+### Added
+
+- `tests/test_host_resource_checker.py` — full coverage of `HostResourceChecker`: the RAM fix, threshold boundaries, byte-valued output, error paths.
+- `tests/test_autoscale.py` — `NotificationManager` validation, formatting and routing; `VMAutoscaler` config loading; CPU/RAM decision logic; `VMResourceManager` scaling helpers.
+
+### Changed
+
+- Removed unused `cached_mem` and `free_mem` variables from `HostResourceChecker`.
+
+## [1.2.0] — 2025-12-09
+
+Published out of order; predates 0.1.1. Added the hotplug fix and the billing tracker. Not covered by `CHANGELOG.md`.
+
+## [0.1.0-docs] — unreleased documentation pass
+
+Comprehensive documentation improvements: `requirements.txt`, `ARCHITECTURE.md`, a troubleshooting section, a table of contents, expanded `SECURITY.md` and `CONTRIBUTING.md`, and the changelog itself.
+
+## [0.1.0] — initial release
+
+CPU and RAM autoscaling, multi-host SSH support, Gotify and SMTP notifications, systemd integration, YAML configuration, host resource safety checks, scaling cooldowns.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,318 @@
+---
+title: Configuration reference
+description: Every key in the Proxmox VM Autoscale config.yaml — type, default, whether it is required, and what the code actually does with it.
+---
+
+# Configuration reference
+
+Location: `/usr/local/bin/vm_autoscale/config.yaml`. The path is hardcoded in `autoscale.py`'s `main()`.
+
+The file is read once at startup. There is no reload signal — restart the service after editing.
+
+::: danger This file holds credentials
+`ssh_password`, `smtp_password` and `app_token` are stored in plain text. The file must be root-owned and mode `600`. Verify with `ls -l`, and see the [hardening guide](/security/hardening).
+:::
+
+## Required sections
+
+Startup fails unless all four of these are present:
+
+```
+scaling_thresholds
+scaling_limits
+proxmox_hosts
+virtual_machines
+```
+
+Missing any of them:
+
+```
+CRITICAL Failed to start VM Autoscaler:
+         Missing required configuration sections: scaling_limits
+```
+
+Note the validator only checks that the **keys exist** — not that their contents make sense.
+
+## `scaling_thresholds`
+
+Usage percentages that trigger a scaling decision. Global; not overridable per VM.
+
+```yaml
+scaling_thresholds:
+  cpu:
+    high: 80
+    low: 20
+  ram:
+    high: 85
+    low: 25
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `cpu.high` | number | when `cpu_scaling` is used | Scale up above this |
+| `cpu.low` | number | when `cpu_scaling` is used | Scale down below this |
+| `ram.high` | number | when `ram_scaling` is used | Scale up above this |
+| `ram.low` | number | when `ram_scaling` is used | Scale down below this |
+
+Comparisons are strict, so a value exactly on a threshold does nothing. Keep the gap between `low` and `high` wide — it is your only protection against oscillation.
+
+## `scaling_limits`
+
+Hard bounds on what any VM may be scaled to. Global.
+
+```yaml
+scaling_limits:
+  min_cores: 1
+  max_cores: 8
+  min_ram_mb: 1024
+  max_ram_mb: 16384
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `min_cores` | int | `1` | |
+| `max_cores` | int | `8` | |
+| `min_ram_mb` | int | `512` | Keep at `1024` or above — NUMA misbehaves below 1 GB |
+| `max_ram_mb` | int | `16384` | |
+
+Limits apply to **every** VM. Per-VM limits are not supported; run separate instances if you need them.
+
+::: warning Behaviour change
+Older versions read these values under names that do not exist in this file, so the defaults above were enforced regardless of what you configured. If you are upgrading, your limits are about to take effect for the first time. Flat top-level `min_cores` / `max_cores` / `min_ram` / `max_ram` keys are still accepted as a fallback for legacy configs.
+:::
+
+## Timing
+
+```yaml
+check_interval: 300
+scale_cooldown: 300
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `check_interval` | int (s) | `300` | Time between polling cycles |
+| `scale_cooldown` | int (s) | `300` | Minimum time between two changes to the same resource on the same VM. **Not present in the shipped config.yaml** — add it if you want a value other than the default |
+
+CPU and RAM have independent cooldown timers. Only an actual change starts one. Timers are in memory and are lost on restart. Setting `scale_cooldown` below `check_interval` has no effect.
+
+## `proxmox_hosts`
+
+```yaml
+proxmox_hosts:
+  - name: pve1
+    host: 192.168.1.10
+    ssh_user: root
+    ssh_password: your_password_here
+    ssh_key: /root/.ssh/id_rsa
+    ssh_port: 22
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Referenced by `virtual_machines[].proxmox_host`; must match exactly |
+| `host` | string | yes | Hostname or IP |
+| `ssh_user` | string | yes | Needs privileges to run `qm set` — in practice `root` |
+| `ssh_password` | string | one of the two | **Takes precedence over `ssh_key` when both are set** |
+| `ssh_key` | path | one of the two | **RSA keys only** — Ed25519 and ECDSA fail to load |
+| `ssh_port` | int | no | Defaults to `22`. Note: `host['ssh_port']` is read directly, so the key must be present |
+
+::: warning Two footguns in the shipped example
+The example config fills in **both** `ssh_password` and `ssh_key` with placeholders. Password wins, so a half-edited config authenticates with the literal string `your_password_here`. Also, `host2` in the example omits `ssh_port` — and the code reads that key unconditionally, so the host raises a `KeyError`. Set `ssh_port` on every host.
+:::
+
+Connections are retried five times with exponential backoff (1, 2, 4, 8, 16 s). Authentication failures are **not** retried.
+
+## `virtual_machines`
+
+```yaml
+virtual_machines:
+  - vm_id: 101
+    proxmox_host: pve1
+    scaling_enabled: true
+    cpu_scaling: true
+    ram_scaling: true
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `vm_id` | int or string | yes | Proxmox VMID. Both types work; strings are used as-is in shell commands |
+| `proxmox_host` | string | yes | Must match a `proxmox_hosts[].name`. **A mismatch silently skips the VM** |
+| `scaling_enabled` | bool | no | Defaults to `false` — omitting it means the VM is never processed |
+| `cpu_scaling` | bool | no | Defaults to `false` |
+| `ram_scaling` | bool | no | Defaults to `false` |
+| `thresholds` | map | — | **Ignored.** Present in the example config but never read |
+
+## `host_limits`
+
+```yaml
+host_limits:
+  max_host_cpu_percent: 90
+  max_host_ram_percent: 90
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `max_host_cpu_percent` | number | yes | No default; a missing key raises `KeyError` per VM |
+| `max_host_ram_percent` | number | yes | Same |
+
+Both gates block scale-**down** as well as scale-up. See [host safety limits](/guide/host-limits).
+
+## `auto_configure_hotplug`
+
+```yaml
+auto_configure_hotplug: true
+```
+
+| Type | Default | Notes |
+|---|---|---|
+| bool | `true` | When on, the service issues `qm set -hotplug cpu,memory,network,disk,usb -numa 1` on guests missing them |
+
+Runs once per VM per service lifetime. NUMA changes need a guest reboot. See [hotplug and NUMA](/guide/hotplug#auto-configure-hotplug).
+
+## `logging`
+
+```yaml
+logging:
+  level: INFO
+  log_file: /var/log/vm_autoscale.log
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `level` | string | `INFO` | |
+| `log_file` | path | `/var/log/vm_autoscale.log` | |
+
+::: info `logging_config.json` overrides this
+If `/usr/local/bin/vm_autoscale/logging_config.json` exists it is loaded via `dictConfig` and **this whole section is ignored**. Since the installer ships that file, the `logging` block in `config.yaml` is inert in a default installation. Edit the JSON instead — see [operations](/guide/operations#log-levels).
+:::
+
+## `gotify`
+
+```yaml
+gotify:
+  enabled: false
+  server_url: https://gotify.example.com
+  app_token: your_gotify_app_token_here
+  priority: 5
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `enabled` | bool | yes | |
+| `server_url` | url | when enabled | Trailing slash stripped automatically |
+| `app_token` | string | when enabled | Application token |
+| `priority` | int | no | Default `5`; per-event priorities override it |
+
+Validated at startup. See [notifications](/guide/notifications#gotify).
+
+## `alerts` (SMTP)
+
+```yaml
+alerts:
+  email_enabled: false
+  email_recipient: admin@example.com
+  smtp_server: smtp.example.com
+  smtp_port: 587
+  smtp_user: your_smtp_user
+  smtp_password: your_smtp_password
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `email_enabled` | bool | yes | |
+| `smtp_server` | string | when enabled | |
+| `smtp_user` | string | when enabled | Also the `From` address |
+| `email_recipient` | string or list | when enabled | |
+| `smtp_port` | int | no | Default `587` |
+| `smtp_password` | string | no | Empty string skips `login()` |
+
+`starttls()` is always called. See [notifications](/guide/notifications#email-smtp).
+
+## `billing`
+
+```yaml
+billing:
+  enabled: false
+  billing_period_days: 30
+  cost_per_cpu_core_per_hour: 0.01
+  cost_per_gb_ram_per_hour: 0.005
+  csv_output_dir: /var/log/vm_autoscale/billing/
+  webhook_script: ""
+  webhook_url: ""
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `false` | Only spec **recording** is automatic |
+| `billing_period_days` | int | `30` | |
+| `cost_per_cpu_core_per_hour` | float | `0.01` | |
+| `cost_per_gb_ram_per_hour` | float | `0.005` | |
+| `csv_output_dir` | path | `/var/log/vm_autoscale/billing/` | Created at startup; holds `billing_data.json` |
+| `webhook_script` | path | `""` | Only fires from report generation |
+| `webhook_url` | url | `""` | Only fires from report generation |
+
+See [billing tracking](/guide/billing) for what is and is not automatic.
+
+## Complete example
+
+```yaml
+scaling_thresholds:
+  cpu: { high: 80, low: 20 }
+  ram: { high: 85, low: 25 }
+
+scaling_limits:
+  min_cores: 1
+  max_cores: 8
+  min_ram_mb: 1024
+  max_ram_mb: 16384
+
+check_interval: 300
+scale_cooldown: 600
+auto_configure_hotplug: false
+
+proxmox_hosts:
+  - name: pve1
+    host: 10.0.0.11
+    ssh_user: root
+    ssh_key: /root/.ssh/vm_autoscale_rsa
+    ssh_port: 22
+  - name: pve2
+    host: 10.0.0.12
+    ssh_user: root
+    ssh_key: /root/.ssh/vm_autoscale_rsa
+    ssh_port: 22
+
+virtual_machines:
+  - { vm_id: 101, proxmox_host: pve1, scaling_enabled: true,  cpu_scaling: true,  ram_scaling: true  }
+  - { vm_id: 102, proxmox_host: pve1, scaling_enabled: true,  cpu_scaling: true,  ram_scaling: false }
+  - { vm_id: 201, proxmox_host: pve2, scaling_enabled: false, cpu_scaling: true,  ram_scaling: true  }
+
+host_limits:
+  max_host_cpu_percent: 85
+  max_host_ram_percent: 90
+
+logging:
+  level: INFO
+  log_file: /var/log/vm_autoscale.log
+
+gotify:
+  enabled: true
+  server_url: https://gotify.internal.example
+  app_token: REPLACE_ME
+  priority: 5
+
+alerts:
+  email_enabled: false
+
+billing:
+  enabled: false
+```
+
+## Validating before restart
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('/usr/local/bin/vm_autoscale/config.yaml'))" \
+  && echo "YAML OK"
+```
+
+This catches syntax errors only. Semantic problems — a `proxmox_host` that matches nothing, a missing `ssh_port` — surface at runtime.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -114,7 +114,7 @@ proxmox_hosts:
 | `ssh_user` | string | yes | Needs privileges to run `qm set` — in practice `root` |
 | `ssh_password` | string | one of the two | **Takes precedence over `ssh_key` when both are set** |
 | `ssh_key` | path | one of the two | **RSA keys only** — Ed25519 and ECDSA fail to load |
-| `ssh_port` | int | no | Defaults to `22`. Note: `host['ssh_port']` is read directly, so the key must be present |
+| `ssh_port` | int | **yes** | There is no default in practice: `host['ssh_port']` is indexed directly rather than via `.get()`, so omitting the key raises `KeyError` and every VM on that host fails. Set it to `22` explicitly |
 
 ::: warning Two footguns in the shipped example
 The example config fills in **both** `ssh_password` and `ssh_key` with placeholders. Password wins, so a half-edited config authenticates with the literal string `your_password_here`. Also, `host2` in the example omits `ssh_port` — and the code reads that key unconditionally, so the host raises a `KeyError`. Set `ssh_port` on every host.

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -1,0 +1,174 @@
+---
+title: Known limitations
+description: A complete, honest catalogue of the known defects and design constraints in Proxmox VM Autoscale, with the impact of each and the workaround where one exists.
+---
+
+# Known limitations
+
+Everything on this page is known and reproducible at the time of writing. It is here so you can decide what you are accepting before you run this against your infrastructure, rather than discovering it from a log line at 3am.
+
+Items are grouped by whether they can bite you silently.
+
+## Silent failure modes
+
+These produce wrong behaviour without an obvious error.
+
+### Metric parsing is format-sensitive
+
+Guest usage comes from scraping a human-readable table:
+
+```bash
+pvesh get /cluster/resources | grep 'qemu/<vmid>' | awk -F '│' '{print $6, $15, $16}'
+```
+
+This depends on the box-drawing separator, on those exact column indices, and on `grep` matching only the intended row. Any of them can change between Proxmox versions.
+
+**Impact:** when parsing fails, usage falls back to `0.0`. Zero is below every reasonable `low` threshold, so **a parse failure is indistinguishable from an idle guest** and walks every affected VM down to its minimum, one step per cycle.
+
+**Detection:** `CPU usage not found in output.` / `RAM memory values not found in output.` in the log.
+
+**Workaround:** verify the command by hand on your Proxmox version before deploying, and alert on those warnings. A `--output-format json` implementation would remove the whole class of problem.
+
+### `grep 'qemu/101'` also matches VMID 1010
+
+The VMID filter is a substring match, so a four-digit VMID beginning with your three-digit one matches too, and `awk` reads whichever row came first.
+
+**Impact:** decisions made from another VM's usage.
+
+**Workaround:** avoid VMID prefixes of each other among managed VMs.
+
+### A `proxmox_host` typo skips the VM without a word
+
+VMs are matched to hosts by exact string equality on `name`. A mismatch means the VM entry is never reached — no warning, no error, it simply never appears in the log.
+
+**Workaround:** after any config change, confirm every managed VM appears in a `VM <id> current usage` line within one cycle.
+
+### Command failures are reported as successes
+
+`execute_command` returns output and exit status without raising on a non-zero status, and the callers that issue `qm set` discard the result. So:
+
+```
+[INFO] RAM balloon set to 4096 MB for VM 101 (hotplug applied).
+```
+
+is logged whether or not `qm set` succeeded, and whether or not the guest honoured it.
+
+**Workaround:** verify with `qm config <vmid>` when a change matters.
+
+### Per-VM `thresholds` are ignored
+
+`config.yaml` shows a `thresholds:` block inside each `virtual_machines` entry. Nothing reads it — only the global `scaling_thresholds` is consulted.
+
+**Impact:** you may believe a VM has bespoke thresholds when it does not.
+
+**Workaround:** run a second instance with its own config for a VM that genuinely needs different numbers.
+
+### Downtime is billed as uptime
+
+`BillingTracker._calculate_resource_cost` accepts the uptime records and never uses them, despite an in-code comment saying cost is charged for uptime only. Compounding this, nothing in the service calls `record_vm_state_change`, so there are no uptime records to begin with — every report shows 100% uptime.
+
+**Impact:** a VM powered off for a week is billed for that week at its last known spec.
+
+**Workaround:** reconcile against your own uptime source before invoicing.
+
+## Documented-but-absent behaviour
+
+### Billing reports are not generated automatically
+
+Enabling `billing` wires up exactly one thing: recording a spec change after each successful scaling action. `generate_period_report`, `export_csv`, `run_webhook`, `record_vm_state_change` and `set_vm_name` are public API that nothing calls.
+
+**Impact:** no CSV appears, no webhook fires, no uptime is tracked.
+
+**Workaround:** the [billing page](/guide/billing#generating-a-report) has a script that calls the API on a schedule.
+
+### `logging` in `config.yaml` is inert by default
+
+If `logging_config.json` exists it is loaded via `dictConfig` and the `logging` section of `config.yaml` is never consulted. The installer ships that file, so in a default install the YAML block does nothing.
+
+**Workaround:** edit `logging_config.json`.
+
+## Operational constraints
+
+### Cooldown state is lost on restart
+
+Cooldown timers live in process memory. `systemctl restart` clears them and the first cycle after can scale immediately. Repeated restarts remove rate limiting entirely.
+
+### `check_interval` is a floor, not a period
+
+Cycles are sequential and blocking: one SSH connection per VM, opened and closed, hosts processed one after another. With many VMs a cycle can exceed `check_interval`, at which point cycles simply run back to back. There is no parallelism and no scheduling guarantee.
+
+### The host gate blocks scale-down too
+
+A node above `max_host_cpu_percent` or `max_host_ram_percent` has *all* scaling suppressed on it, including shrinking idle guests — the one action that would give the node headroom back.
+
+### Step sizes are not configurable
+
+Fixed at 1 core and 512 MB per action, in `vm_manager.py`. Recovering from a large jump takes many cycles.
+
+### Limits are global
+
+`scaling_limits` applies to every VM. A 2-core web server and a 16-core database cannot have different ceilings in one instance.
+
+### Single instance, no HA
+
+One process, no leader election, no shared state. Two instances managing the same VM will fight, since neither sees the other's cooldowns.
+
+### `ssh_port` is read unconditionally
+
+`host['ssh_port']` is indexed directly rather than via `.get()`, so a host entry without that key raises `KeyError` and every VM on it fails. The shipped example config omits it on `host2`.
+
+**Workaround:** set `ssh_port` on every host.
+
+### `ssh_password` silently overrides `ssh_key`
+
+When both are present the password is used. The shipped example fills in both with placeholders.
+
+## Security constraints
+
+Covered in full in the [threat model](/security/); summarised here.
+
+### Only RSA SSH keys are supported
+
+The key file is loaded specifically as an RSA key, so Ed25519 and ECDSA keys fail to load — despite `SECURITY.md` recommending Ed25519.
+
+**Workaround:** `ssh-keygen -t rsa -b 4096`, or use password authentication.
+
+### SSH host keys are accepted automatically
+
+The client uses an auto-add policy: any host key is trusted on first contact and no pinning is performed. An attacker positioned between the service and a node can present their own key and receive your root credentials.
+
+**Workaround:** the [hardening guide](/security/hardening#pin-ssh-host-keys) shows how to constrain this at the network and configuration level.
+
+### Credentials are stored in plain text
+
+`ssh_password`, `smtp_password` and `app_token` are read from `config.yaml` as-is. There is no secrets backend and no environment-variable support.
+
+**Workaround:** mode `600`, root-owned, on an encrypted filesystem; prefer key authentication over passwords.
+
+### The service runs as root, unconfined
+
+The shipped unit sets `User=root` with no systemd sandboxing directives.
+
+**Workaround:** [hardening drop-in](/security/hardening#confine-the-systemd-unit).
+
+### VMIDs are interpolated into shell commands
+
+`vm_id` from the config is formatted straight into command strings without validation. Since the config is administrator-controlled this is not remotely exploitable, but a malformed VMID produces malformed commands rather than a clear error.
+
+## Project-level notes
+
+### Release tags are not in chronological order
+
+`v1.2.0` was published in December 2025, `v0.1.1` in April 2026 — and `v0.1.1` is the current release. The numbering does not reflect ordering, and the changelog does not mention `v1.2.0`.
+
+### No dry-run mode
+
+There is no way to see what the service *would* do. The closest approximation is `scaling_enabled: false` everywhere, which produces the monitoring output without acting.
+
+### No metrics endpoint
+
+No Prometheus exporter, no health endpoint, no structured events. Monitoring means parsing the log — see [operations](/guide/operations#monitoring-the-autoscaler-itself).
+
+---
+
+Found something not on this list? [Open an issue](https://github.com/fabriziosalmi/proxmox-vm-autoscale/issues/new/choose). For anything with security impact, follow [responsible disclosure](/security/disclosure) instead.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,0 +1,198 @@
+---
+title: Python modules
+description: API reference for the Proxmox VM Autoscale Python modules — classes, public methods, arguments and return values.
+---
+
+# Python modules
+
+Useful if you are extending the service, calling `BillingTracker` from your own script, or reading the source. Paths are relative to `/usr/local/bin/vm_autoscale/`.
+
+## `autoscale.py`
+
+### `class VMAutoscaler`
+
+The orchestrator.
+
+```python
+VMAutoscaler(config_path: str, logging_config_path: Optional[str] = None)
+```
+
+| Method | Signature | Notes |
+|---|---|---|
+| `run` | `() -> None` | Blocking main loop. Exits on `KeyboardInterrupt` |
+| `process_vm` | `(host: dict, vm: dict) -> None` | One VM, one cycle. Catches and notifies its own errors |
+| `_load_config` | `(config_path: str) -> dict` | Static. Raises `FileNotFoundError` or `ConfigurationError` |
+| `_setup_logging` | `(path: Optional[str]) -> Logger` | JSON config wins over the YAML `logging` section |
+| `_get_vm_manager` | `(ssh_client, vm_id) -> VMResourceManager` | Cached per VMID; rebinds the SSH client |
+| `_handle_cpu_scaling` | `(vm_manager, vm_id, cpu_usage: float) -> None` | |
+| `_handle_ram_scaling` | `(vm_manager, vm_id, ram_usage: float) -> None` | |
+| `_record_billing_spec` | `(vm_manager, vm_id) -> None` | No-op when billing is disabled |
+
+### `class NotificationManager`
+
+```python
+NotificationManager(config: dict, logger: logging.Logger)
+```
+
+Validates channel configuration in the constructor.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `send_notification` | `(message, priority: Optional[int] = None) -> None` | Fans out to all enabled channels; never raises |
+| `send_gotify_notification` | `(message: str, priority=None) -> None` | Raises on HTTP failure |
+| `send_smtp_notification` | `(message: str) -> None` | Raises on SMTP failure |
+| `validate_notification_config` | `() -> None` | Raises `ConfigurationError` |
+| `_format_message` | `(message) -> str` | Joins tuples, stringifies everything else |
+
+### `class ConfigurationError(Exception)`
+
+Raised for missing sections and incomplete channel configuration.
+
+## `vm_manager.py`
+
+### `class VMResourceManager`
+
+```python
+VMResourceManager(ssh_client, vm_id, config: dict)
+```
+
+Runs hotplug auto-configuration in the constructor when `auto_configure_hotplug` is true.
+
+**Public methods**
+
+| Method | Signature | Returns |
+|---|---|---|
+| `is_vm_running` | `(retries=3, delay=5) -> bool` | `False` if undeterminable after retries |
+| `get_resource_usage` | `() -> tuple[float, float]` | `(cpu_pct, ram_pct)`; `(0.0, 0.0)` on any failure |
+| `can_scale` | `(resource: str = "cpu") -> bool` | Read-only cooldown check |
+| `scale_cpu` | `(direction: "up" \| "down") -> bool` | `True` only if a change was made |
+| `scale_ram` | `(direction: "up" \| "down") -> bool` | `True` only if a change was made |
+
+**Internal helpers worth knowing**
+
+| Method | Purpose |
+|---|---|
+| `_mark_scaled(resource)` | Starts the cooldown for that resource |
+| `_scaling_limit(key, legacy_key, default)` | `scaling_limits` → flat key → default |
+| `_get_min_cores` / `_get_max_cores` | Resolved limits |
+| `_get_min_ram` / `_get_max_ram` | Resolved limits, MB |
+| `_get_current_cores` / `_get_current_vcpus` / `_get_current_ram` | Parsed from `qm config` |
+| `_check_hotplug_enabled()` | `(cpu_hotplug, memory_hotplug)` |
+| `_check_numa_enabled()` | `bool` |
+| `_set_cores` / `_set_vcpus` / `_set_ram` | Issue `qm set` |
+| `_parse_cpu_usage` / `_parse_ram_usage` | Regex over `pvesh` table output |
+
+Failing getters return conservative defaults — `1` core, `512` MB — rather than raising. A transient SSH failure during a config read therefore looks like a very small VM.
+
+## `ssh_utils.py`
+
+### `class SSHClient`
+
+```python
+SSHClient(host, user, password=None, key_path=None, port=22)
+```
+
+| Method | Signature | Notes |
+|---|---|---|
+| `connect` | `() -> None` | Reuses an active transport. 5 attempts, backoff 1/2/4/8/16 s. Auth failures raise immediately |
+| `execute_command` | `(command: str, timeout=30) -> tuple[str, str, int]` | `(stdout, stderr, exit_status)`. Retries with reconnect; **does not raise on non-zero exit** |
+| `close` | `() -> None` | Idempotent |
+| `is_connected` | `() -> bool` | |
+| `__enter__` / `__exit__` | | Context-manager support |
+
+Notes: the missing-host-key policy is auto-add, and `key_path` is loaded as an **RSA** key specifically. Both are covered in the [threat model](/security/).
+
+## `host_resource_checker.py`
+
+### `class HostResourceChecker`
+
+```python
+HostResourceChecker(ssh_client)
+```
+
+| Method | Signature | Notes |
+|---|---|---|
+| `check_host_resources` | `(max_cpu_pct, max_ram_pct) -> bool` | `True` when both are within limits. Raises on JSON or field errors |
+
+RAM is `memory.used / memory.total`, matching the Proxmox web UI.
+
+## `billing_tracker.py`
+
+### `class BillingTracker`
+
+```python
+BillingTracker(config: dict, logger: logging.Logger)
+```
+
+Creates `csv_output_dir` and loads `billing_data.json` on construction.
+
+| Method | Signature | Called by the service? |
+|---|---|---|
+| `record_spec_change` | `(vm_id, cpu_cores, ram_mb, timestamp=None) -> None` | **Yes** |
+| `record_vm_state_change` | `(vm_id, state: "started" \| "stopped", timestamp=None) -> None` | No |
+| `set_vm_name` | `(vm_id, vm_name) -> None` | No |
+| `calculate_billing_period` | `(vm_id, period_start, period_end) -> BillingReport` | No |
+| `export_csv` | `(report, output_path=None) -> str` | No |
+| `run_webhook` | `(report) -> None` | No |
+| `generate_period_report` | `(vm_id) -> Optional[BillingReport]` | No |
+
+Every write persists the entire state file. See [billing](/guide/billing).
+
+### Dataclasses
+
+```python
+@dataclass
+class SpecChangeRecord:
+    timestamp: datetime
+    cpu_cores: int
+    ram_mb: int
+
+@dataclass
+class StateChangeRecord:
+    timestamp: datetime
+    state: str            # "started" | "stopped"
+
+@dataclass
+class BillingReport:
+    vm_id: str
+    vm_name: str
+    period_start: datetime
+    period_end: datetime
+    min_cpu_cores: int
+    max_cpu_cores: int
+    avg_cpu_cores: float
+    min_ram_mb: int
+    max_ram_mb: int
+    avg_ram_mb: float
+    total_uptime_hours: float
+    total_downtime_hours: float
+    uptime_percentage: float
+    spec_changes: list[dict]
+    total_cost: float
+```
+
+All three expose `to_dict()`; `BillingReport.to_dict()` is what webhooks receive.
+
+## Importing from your own code
+
+```python
+import sys
+sys.path.insert(0, "/usr/local/bin/vm_autoscale")
+
+from ssh_utils import SSHClient
+from vm_manager import VMResourceManager
+
+config = {
+    "auto_configure_hotplug": False,
+    "scale_cooldown": 0,
+    "scaling_limits": {"min_cores": 1, "max_cores": 8,
+                       "min_ram_mb": 1024, "max_ram_mb": 16384},
+}
+
+with SSHClient(host="10.0.0.11", user="root",
+               key_path="/root/.ssh/vm_autoscale_rsa") as ssh:
+    vm = VMResourceManager(ssh, 101, config)
+    print(vm.is_vm_running(), vm.get_resource_usage())
+```
+
+There is no installable package and no stable API contract — these are scripts on a path. Pin to a commit if you build on them.

--- a/docs/security/disclosure.md
+++ b/docs/security/disclosure.md
@@ -1,0 +1,86 @@
+---
+title: Reporting a vulnerability
+description: How to responsibly disclose a security vulnerability in Proxmox VM Autoscale, what to include, and what response to expect.
+---
+
+# Reporting a vulnerability
+
+## Do not open a public issue
+
+Report privately by email:
+
+**fabrizio.salmi@gmail.com**
+
+Public disclosure before a fix exists puts every deployment at risk — and these deployments hold root credentials for hypervisors.
+
+## What to include
+
+- **What it is** — the class of issue and the component affected
+- **How to reproduce** — steps, a proof of concept, or the code path
+- **Impact** — what an attacker gains, and from what starting position
+- **Version** — release tag or commit hash
+- **Suggested fix**, if you have one
+- **How you would like to be credited**, or that you prefer to stay anonymous
+
+## What to expect
+
+| Stage | Timeline |
+|---|---|
+| Acknowledgement | Within 48 hours |
+| Initial assessment and a plan | Within 7 days |
+| Fix | Depends on severity and complexity |
+| Advisory and release | Together with the fix |
+
+You will be kept informed as the fix progresses, credited in the advisory unless you prefer otherwise, and told when it is safe to publish.
+
+## Scope
+
+**In scope** — anything in this repository: the Python modules, `install.sh`, the systemd unit, the shipped configuration and the documentation where it recommends something unsafe.
+
+**Out of scope**
+
+- Vulnerabilities in Proxmox VE itself → [Proxmox security](https://pve.proxmox.com/wiki/Security)
+- Vulnerabilities in `paramiko`, `PyYAML` or `requests` → report upstream, though do tell us if this project's usage makes one exploitable
+- Issues requiring root on the autoscaler host — root there is [already total compromise](/security/#root-on-the-autoscaler-host) by design
+- Weaknesses already documented on the [known limitations](/reference/limitations) page — they are known; a *new* exploitation path for one of them is very much in scope
+
+## Already-known weaknesses
+
+Please check these before reporting, so your effort goes somewhere useful:
+
+- SSH host keys are auto-accepted with no pinning
+- Credentials are stored in plain text in `config.yaml`
+- The service requires and runs as root
+- `install.sh` is fetched over HTTPS and executed unverified
+- VMIDs are interpolated into shell command strings without validation
+
+All are documented in the [threat model](/security/).
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| `main` | ✅ |
+| Latest release (`v0.1.1`) | ✅ |
+| Older tags | ⚠️ Alpha — upgrade |
+
+Note that release tags are not in chronological order: `v1.2.0` predates `v0.1.1`.
+
+## machine-readable
+
+A [`security.txt`](/proxmox-vm-autoscale/.well-known/security.txt) is published under this site, per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).
+
+::: info About its location
+RFC 9116 places `security.txt` at the root of a domain. This site lives under a path on `github.io`, so the file is served from the project path rather than the canonical one. It is provided for completeness; the email address above is the authoritative contact.
+:::
+
+## Security updates
+
+When an issue is fixed:
+
+1. It is developed and tested privately.
+2. A GitHub security advisory is published.
+3. A release is tagged with the fix.
+4. Release notes describe the issue and the required action.
+
+[Watch the repository](https://github.com/fabriziosalmi/proxmox-vm-autoscale) → Custom → Releases to be notified.

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -1,0 +1,246 @@
+---
+title: Hardening guide
+description: Concrete steps to reduce the exposure of a Proxmox VM Autoscale deployment — file permissions, SSH configuration, systemd confinement and log handling.
+---
+
+# Hardening guide
+
+Ordered roughly by effort-to-benefit. Everything here is optional; none of it is done for you beyond the file permissions the installer sets.
+
+## Verify config permissions
+
+Do this first, and after every install or upgrade.
+
+```bash
+ls -l /usr/local/bin/vm_autoscale/config.yaml
+# want: -rw------- 1 root root
+```
+
+If it shows anything broader:
+
+```bash
+sudo chown root:root /usr/local/bin/vm_autoscale/config.yaml
+sudo chmod 600 /usr/local/bin/vm_autoscale/config.yaml
+sudo chown -R root:root /etc/vm_autoscale
+sudo chmod 700 /etc/vm_autoscale
+sudo chmod 600 /etc/vm_autoscale/config.yaml.backup
+```
+
+::: danger If you installed before the permissions fix
+The installer's recursive `chmod 755` left the config world-readable, meaning every local user could read your Proxmox root password. Fix the permissions **and rotate that password and any SMTP credentials** — assume they were exposed for as long as the file was readable.
+:::
+
+## Use a dedicated SSH key
+
+Do not reuse an existing admin key.
+
+```bash
+sudo ssh-keygen -t rsa -b 4096 -f /root/.ssh/vm_autoscale_rsa -N "" \
+  -C "vm-autoscale@$(hostname -f)"
+sudo chmod 600 /root/.ssh/vm_autoscale_rsa
+```
+
+```bash
+sudo ssh-copy-id -i /root/.ssh/vm_autoscale_rsa.pub root@10.0.0.11
+```
+
+```yaml
+proxmox_hosts:
+  - name: pve1
+    host: 10.0.0.11
+    ssh_user: root
+    ssh_key: /root/.ssh/vm_autoscale_rsa
+    ssh_port: 22
+    # ssh_password intentionally absent — it would override the key
+```
+
+::: warning RSA specifically
+The key is loaded as an RSA key. Ed25519 and ECDSA keys will not load, regardless of how much better a choice they would otherwise be. Use `-t rsa -b 4096` until that changes.
+:::
+
+Remove `ssh_password` entirely — leaving it set means the key is ignored.
+
+## Restrict what the key can do
+
+You cannot get to true least privilege — the service genuinely needs `qm set` — but you can bound the key.
+
+```
+# /root/.ssh/authorized_keys on each Proxmox node
+from="10.0.0.5",no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-pty ssh-rsa AAAA...
+```
+
+`from=` is the useful part: the key becomes worthless from anywhere but the autoscaler's address. `no-pty` prevents interactive use while still allowing command execution.
+
+A forced command is tempting but impractical here, since the service issues several different commands with variable arguments. A wrapper script that whitelists `qm status|config|set` and `pvesh get` for specific VMIDs is possible if you want to invest in it.
+
+## Pin SSH host keys
+
+The client trusts any host key it is offered and does not pin. You cannot change that from configuration, so mitigate around it:
+
+- **Segment the network.** Put management SSH on a dedicated VLAN reachable only from the autoscaler.
+- **Use addresses, not names.** `host: 10.0.0.11` removes DNS from the attack path.
+- **Pre-populate `known_hosts`** so at least an interactive `ssh` from that box fails loudly if a key changes:
+
+  ```bash
+  ssh-keyscan -H 10.0.0.11 | sudo tee -a /root/.ssh/known_hosts
+  ```
+
+  The service will not consult it, but it gives you a tripwire.
+- **Alert on host key changes** with a periodic `ssh-keyscan` diff.
+
+## Confine the systemd unit
+
+The shipped unit runs as root with no sandboxing. A drop-in adds meaningful confinement without touching the packaged file:
+
+```bash
+sudo systemctl edit vm_autoscale.service
+```
+
+```ini
+[Service]
+# Filesystem
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/log /var/log/vm_autoscale
+ReadOnlyPaths=/usr/local/bin/vm_autoscale
+
+# Privileges
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+
+# Network — outbound only, no unusual address families
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Restart behaviour
+RestartSec=10
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart vm_autoscale.service
+sudo systemctl status vm_autoscale.service
+systemd-analyze security vm_autoscale.service
+```
+
+::: warning Test this
+`ProtectSystem=strict` makes the whole filesystem read-only except `ReadWritePaths`. If you changed `log_file` or `csv_output_dir`, add those paths. Watch the first cycle after applying it.
+:::
+
+Running the service on a Proxmox node itself limits how far you can go — `qm` needs access that heavy confinement would break. The directives above are safe because the service only *SSHes out*; it does not run `qm` locally.
+
+## Protect the log
+
+The log names your nodes and VMs and reveals capacity patterns.
+
+```bash
+sudo chmod 640 /var/log/vm_autoscale.log
+sudo chown root:adm /var/log/vm_autoscale.log
+```
+
+Rotate it — nothing does by default:
+
+```
+# /etc/logrotate.d/vm_autoscale
+/var/log/vm_autoscale.log {
+    weekly
+    rotate 8
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    create 0640 root adm
+}
+```
+
+`copytruncate` is required: the service holds the file open for its lifetime.
+
+For an audit trail, ship the journal somewhere append-only:
+
+```
+# /etc/rsyslog.d/50-vm-autoscale.conf
+if $programname == 'python3' and $msg contains 'vm_autoscale' then @@logs.internal.example:514
+```
+
+## Firewall the outbound path
+
+The service needs exactly three kinds of outbound connection: SSH to your nodes, HTTPS to Gotify, SMTP to your relay. Nothing else.
+
+```bash
+# nftables sketch — adapt to your ruleset
+nft add rule inet filter output ip daddr 10.0.0.0/24 tcp dport 22 accept
+nft add rule inet filter output ip daddr 10.0.1.20   tcp dport 443 accept
+nft add rule inet filter output ip daddr 10.0.1.25   tcp dport 587 accept
+```
+
+Egress filtering is what turns "the autoscaler was compromised" into "the autoscaler was compromised and could only talk to three known hosts".
+
+## Keep dependencies current
+
+```bash
+pip3 install pip-audit
+pip-audit -r /usr/local/bin/vm_autoscale/requirements.txt
+```
+
+Dependabot watches the repository weekly. On your host you have to run the upgrade yourself:
+
+```bash
+pip3 install --upgrade paramiko PyYAML requests
+sudo systemctl restart vm_autoscale.service
+```
+
+## Do not install by piping curl into bash
+
+```bash
+# Fetch, read, then run
+curl -fsSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-vm-autoscale/main/install.sh \
+  -o /tmp/install.sh
+less /tmp/install.sh
+sudo bash /tmp/install.sh
+```
+
+Better still, pin to a release rather than tracking `main`:
+
+```bash
+sudo git clone --branch v0.1.1 --depth 1 \
+  https://github.com/fabriziosalmi/proxmox-vm-autoscale /usr/local/bin/vm_autoscale
+```
+
+## Rotate credentials
+
+Nothing rotates automatically. On a schedule that suits you:
+
+```bash
+# New key
+sudo ssh-keygen -t rsa -b 4096 -f /root/.ssh/vm_autoscale_rsa.new -N ""
+sudo ssh-copy-id -i /root/.ssh/vm_autoscale_rsa.new.pub root@10.0.0.11
+# Update config.yaml, restart, verify a full cycle, then remove the old key
+# from authorized_keys on every node
+```
+
+Rotate immediately if `config.yaml` was ever readable by a non-root user, if the host was compromised, or if someone with access has left.
+
+## Checklist
+
+- [ ] `config.yaml` is `600`, root-owned
+- [ ] `/etc/vm_autoscale` is `700`, backup inside is `600`
+- [ ] Key authentication, dedicated RSA key, `ssh_password` removed
+- [ ] `from=` restriction on the key in `authorized_keys`
+- [ ] Management SSH on a segmented network
+- [ ] systemd hardening drop-in applied and verified
+- [ ] Log permissions set and rotation configured
+- [ ] Outbound firewall rules in place
+- [ ] `pip-audit` clean
+- [ ] Installed from a pinned release, not `curl | bash`
+- [ ] Credential rotation scheduled

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,0 +1,108 @@
+---
+title: Threat model
+description: What Proxmox VM Autoscale exposes, what an attacker gains at each level of access, and which risks are inherent to the design versus fixable defects.
+---
+
+# Threat model
+
+This service holds credentials for `root` on your hypervisors and executes commands against live guests. That is a high-value target. This page states plainly what it exposes, so you can decide where to run it and what to protect.
+
+## What the service can do
+
+Given its credentials, the service can — and does — run arbitrary `qm` and `pvesh` commands as root on every node in its config. In practice it only issues `qm status`, `qm config`, `qm set` and `pvesh get`, but nothing constrains it to those. **Anyone who can modify `config.yaml`, `autoscale.py` or the module files can run any command as root on every configured hypervisor.**
+
+That is the core of the model. Everything else follows from it.
+
+## Assets
+
+| Asset | Where it lives | Exposure if compromised |
+|---|---|---|
+| Proxmox root SSH password or key | `config.yaml`, plain text | Full control of every configured node, and therefore every guest on them |
+| SMTP credentials | `config.yaml`, plain text | Mail relay abuse, spoofed mail from your domain |
+| Gotify application token | `config.yaml`, plain text | Push notifications to your operators; useful for social engineering |
+| SSH private key | Path referenced in `config.yaml` | Same as the password |
+| The service code | `/usr/local/bin/vm_autoscale/` | Arbitrary root execution on all nodes at the next cycle |
+| Log file | `/var/log/vm_autoscale.log` | VMIDs, node names, usage patterns, capacity — reconnaissance |
+| Billing data | `billing_data.json` | Customer capacity history |
+
+## Attacker positions
+
+### Unprivileged local user on the autoscaler host
+
+**Before the recent fix**, the installer's recursive `chmod 755` left `config.yaml` world-readable — so any local user could simply read the Proxmox root password. If you installed before that change, [check and fix it now](/security/hardening#verify-config-permissions).
+
+After the fix, `config.yaml` is mode `600` and root-owned. What remains readable to a local user:
+
+- `/var/log/vm_autoscale.log`, unless you restrict it — node names, VMIDs, capacity
+- The service code itself (mode `755`), which reveals the config path and structure
+- Process arguments via `/proc`, which show the script path but no credentials
+
+### Network attacker between the service and a node
+
+The SSH client uses an **auto-add host key policy**: any host key presented is trusted, and no pinning is performed on subsequent connections. An attacker able to intercept or redirect the connection can present their own key and receive the root password or complete a key-based handshake against their own server.
+
+This is the most serious design-level exposure. It is inherent to the current implementation, not a misconfiguration. Mitigate at the network layer — see [hardening](/security/hardening#pin-ssh-host-keys).
+
+### Root on the autoscaler host
+
+Total compromise of every configured hypervisor. There is no additional boundary: the credentials are readable, the code is modifiable, and the next cycle executes whatever it now says.
+
+Treat the autoscaler host as being in the **same trust zone as the hypervisors themselves**. Running it on a general-purpose jump box that other people use is a mistake.
+
+### Someone who can open a pull request
+
+Merged code runs as root on hypervisors at the next service restart. The installer clones `main` directly, so anything merged reaches installations that reinstall. Review contributions with that in mind.
+
+### Compromise of the installation path
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/.../main/install.sh)
+```
+
+This executes whatever is on `main` at that moment, as root, with no signature and no checksum. A compromised GitHub account, a malicious merge, or a TLS interception all lead to root execution. It is the recommended install method in the README, and it is a real supply-chain exposure. Read the script first, or [install manually](/guide/installation#option-b-manual-install).
+
+## Design-level exposures
+
+These are properties of how the service works. They are not going to be fixed by tightening a permission.
+
+| Exposure | Why it exists | Can you mitigate it? |
+|---|---|---|
+| **Root SSH required** | Every action is a `qm` command | Not today; there is no least-privilege mode |
+| **Credentials in plain text** | No secrets backend | File permissions and disk encryption only |
+| **Auto-add host keys** | Paramiko `AutoAddPolicy` | Network segmentation, dedicated management VLAN |
+| **Service runs unconfined as root** | Shipped unit sets `User=root` with no sandboxing | Yes — [systemd drop-in](/security/hardening#confine-the-systemd-unit) |
+| **VMIDs interpolated into shell strings** | No validation on `vm_id` | Config is admin-controlled, so not remotely exploitable |
+| **No audit trail beyond the log** | No structured events | Ship the log somewhere append-only |
+
+## What is not a risk
+
+Worth stating, to keep attention where it belongs:
+
+- **No network listener.** The service binds nothing. It cannot be reached from outside; it only makes outbound connections.
+- **No inbound API, no web UI, no authentication surface.**
+- **No guest agent.** Nothing is installed inside your VMs.
+- **Outbound connections are limited** to SSH to configured nodes, HTTPS to your Gotify server, and SMTP to your relay.
+- **No telemetry.** The service phones nothing home. See [privacy](/privacy).
+
+## Dependencies
+
+Three direct dependencies: `paramiko`, `PyYAML`, `requests`. All eight historical Dependabot alerts on this repository — mostly in `cryptography`, Paramiko's transitive dependency — are resolved. Dependabot runs weekly on pip.
+
+Keep them current:
+
+```bash
+pip3 install --upgrade paramiko PyYAML requests
+pip3 install pip-audit && pip-audit
+```
+
+## Recommended posture
+
+1. Run it on a dedicated host, or on a Proxmox node itself — not on a shared jump box.
+2. Use key authentication with a dedicated RSA key used for nothing else.
+3. Keep management SSH on a segmented network.
+4. Apply the [systemd hardening drop-in](/security/hardening#confine-the-systemd-unit).
+5. Verify `config.yaml` is `600` and root-owned after every install or upgrade.
+6. Ship logs off-host if you need an audit trail.
+7. Subscribe to releases so security fixes reach you.
+
+Full step-by-step: the [hardening guide](/security/hardening). To report something: [responsible disclosure](/security/disclosure).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2564 @@
+{
+  "name": "proxmox-vm-autoscale-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "proxmox-vm-autoscale-docs",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+      "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+      "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+      "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+      "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+      "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+      "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+      "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+      "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+      "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+      "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+      "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+      "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+      "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+      "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.94",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.94.tgz",
+      "integrity": "sha512-l8UWzVxKaqZd9ABsE/M/9p6NyGkQnmCnOoZyhQmjlXCtY5PuL2rcWxOFk2l9pk7ux3ERMPkTLE4jl6kQpTkwxA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.42",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/runtime-core": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+      "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.23.0",
+        "@algolia/client-abtesting": "5.57.0",
+        "@algolia/client-analytics": "5.57.0",
+        "@algolia/client-common": "5.57.0",
+        "@algolia/client-insights": "5.57.0",
+        "@algolia/client-personalization": "5.57.0",
+        "@algolia/client-query-suggestions": "5.57.0",
+        "@algolia/client-search": "5.57.0",
+        "@algolia/ingestion": "1.57.0",
+        "@algolia/monitoring": "1.57.0",
+        "@algolia/recommend": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.1.0.tgz",
+      "integrity": "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-sfc": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/server-renderer": "3.5.42",
+        "@vue/shared": "3.5.42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "proxmox-vm-autoscale-docs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Documentation site for Proxmox VM Autoscale",
+  "license": "MIT",
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}


### PR DESCRIPTION
A 17-page documentation site under `docs/`, published to **https://fabriziosalmi.github.io/proxmox-vm-autoscale/** by a GitHub Actions workflow using the Pages deployment API — no `gh-pages` branch, matching the "GitHub Actions" source already enabled on this repo.

> [!IMPORTANT]
> Merge **after** #45. The docs describe the post-#45 behaviour of `scaling_limits` and the cooldown. Merging this first would leave those three pages describing behaviour that does not exist yet.

## Structure

| Section | Pages |
|---|---|
| **Guide** | Introduction · Installation · Your first scaling VM · How scaling decisions are made · Hotplug and NUMA · Host safety limits · Notifications · Billing tracking · Operations · Troubleshooting · FAQ |
| **Reference** | Configuration reference · Architecture · Python modules · Known limitations · Changelog |
| **Security** | Threat model · Hardening guide · Reporting a vulnerability |
| **Other** | Contributing · Privacy |

## The documentation describes what the code does

Where behaviour diverges from what the README currently promises, the divergence is documented rather than repeated. Everything below is verified against the source and collected on the **Known limitations** page:

- The per-VM `thresholds:` block in `config.yaml` is never read — only the global `scaling_thresholds` is.
- Billing records spec changes but **generates no reports**: `generate_period_report`, `export_csv`, `run_webhook`, `record_vm_state_change` and `set_vm_name` are never called by the service. The billing page ships a script that calls them.
- `_calculate_resource_cost` accepts uptime records and ignores them, so downtime is billed as uptime — and nothing records uptime in the first place.
- `paramiko.RSAKey.from_private_key_file` means **only RSA keys load**, despite `SECURITY.md` recommending Ed25519.
- Guest metrics come from scraping a `pvesh` table; on a parse failure usage falls back to `0.0`, which reads as "idle" and **walks VMs down to their minimum**.
- `grep 'qemu/101'` also matches VMID `1010`.
- The SSH client uses an auto-add host key policy with no pinning.
- `host['ssh_port']` is indexed directly, so a host entry without that key raises `KeyError` — and the shipped example config omits it on `host2`.
- `ssh_password` silently overrides `ssh_key`, and the shipped example fills in both.
- The `logging` section of `config.yaml` is inert whenever `logging_config.json` exists, which it does in every default install.
- Release tags are not in chronological order: `v1.2.0` predates `v0.1.1`.

## Machine-readable surfaces

- **`sitemap.xml`** — generated at build time, 22 absolute URLs
- **Per-page canonical + `og:url`** via `transformPageData` (without it every page advertises the site root)
- **JSON-LD `@graph`** — `WebSite`, `Person`, `SoftwareSourceCode`, `SoftwareApplication`, cross-referenced by `@id`
- **`llms.txt`** — site map for answer engines, including the constraints a reader should know before relying on the project
- **`.well-known/security.txt`** — RFC 9116, with `Expires`; flagged in-file as non-canonical because the site is served from a path, not a domain root
- **`robots.txt`** pointing at the sitemap
- **Privacy page** — no analytics, no cookies, no third-party embeds, no external fonts, local in-browser search; documents GitHub's own request logging as the one thing outside our control

## CI

`.github/workflows/docs.yml` builds on pushes touching `docs/`, and **fails the build** if `sitemap.xml`, `robots.txt`, `llms.txt`, `.well-known/security.txt` or `favicon.svg` is missing or empty, or if the JSON-LD block or canonical link is absent from `index.html`.

## Verification

- Build clean on VitePress 1.6.4; dead internal links would fail the build and do not
- 22 URLs in the sitemap; canonical and `og:url` correct on sampled subpages
- `.well-known/` correctly copied out of `public/`
- No console errors
- Checked at 375px: the wide reference tables scroll inside themselves and the page does not overflow horizontally

## Follow-ups not in this PR

- Set the repository **homepage** to the docs URL once Pages is live
- The **wiki is enabled but empty** (`.wiki.git` does not exist), so the Wiki tab is a 404 — worth disabling now that docs exist
- Consider enabling **Discussions** for support questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)