### PR TITLE
fix: per-VM thresholds, SSH host key verification, and billing that actually works

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,7 +83,7 @@ them. The only durable state the service writes is the billing JSON file.
 
 ## Tests
 
-138 unit tests in `tests/`, run with `pytest`. SSH is mocked throughout, so
+170 unit tests in `tests/`, run with `pytest`. SSH is mocked throughout, so
 anything depending on real `pvesh` output format is not covered by CI.
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Per-VM `thresholds` are read.** The block has been in the example
+  `config.yaml` since the beginning and nothing consulted it; every VM used the
+  global `scaling_thresholds`. Both the flat shape (`cpu_high`, `cpu_low`,
+  `ram_high`, `ram_low`) and the nested one (`cpu: { high, low }`) now work, and
+  any bound you omit keeps the global value.
+- **Billing generates reports.** `generate_period_report` existed but nothing
+  called it, so enabling billing produced a growing state file and no CSV, no
+  webhook and no report. The main loop now emits one per VM once a billing
+  period elapses; the period clock is persisted, so it survives restarts.
+- **Billing records VM start/stop.** `record_vm_state_change` was never called,
+  which is why every report showed 100% uptime. Transitions are now recorded —
+  transitions only, not one entry per poll.
+- **Downtime is no longer billed as uptime.** `_calculate_resource_cost`
+  accepted the uptime records and ignored them, so a VM powered off for a week
+  was billed for that week at its last known spec. Cost is now charged only for
+  the hours a VM was actually running.
+- **A VM that never changed spec is no longer billed zero.** Spec changes are
+  events, so a guest that held one size for the whole period had no records
+  inside it and cost nothing. The spec in effect at `period_start` is now
+  carried in, and so is the running state.
+- **`ssh_port` has a default again.** It was indexed directly rather than via
+  `.get()`, so omitting it raised `KeyError` and every VM on that host failed.
+  The shipped example omitted it on `host2`.
+
+### Security
+- **SSH host keys are verified.** The client set `AutoAddPolicy` without ever
+  loading or saving a known_hosts file, so every connection accepted whatever
+  key it was offered and remembered nothing — no protection at all for a
+  service holding root credentials. New `ssh_host_key_policy`, default
+  `accept-new`: a node's key is recorded on first contact and a later change is
+  refused. `strict` requires a pre-populated `ssh_known_hosts`; `auto`
+  reproduces the old behaviour and logs a warning. A mismatch is fatal and is
+  not retried.
+
+### Added
+- `tests/test_thresholds_hostkeys_billing.py`: 32 regression tests (170 total)
+  covering threshold resolution and precedence, all three host key policies and
+  the mismatch path, uptime-weighted cost, period carry-in, the persisted report
+  clock, and the autoscaler's own billing plumbing.
+
 ## [1.4.0] - 2026-09-05
 
 > **Upgrade note.** A VM whose usage cannot be read now **stops scaling**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,7 +63,7 @@ These are documented, not hidden. Please check them before reporting.
 
 | Weakness | Status |
 |---|---|
-| SSH host keys are auto-accepted, with no pinning | Design-level; mitigate by network segmentation |
+| Host key trust is first-use by default | `accept-new` records and pins after the first contact; use `strict` with a pre-populated `ssh_known_hosts` to close the first-use window |
 | Credentials stored in plain text in `config.yaml` | No secrets backend; mitigate with mode `600` and disk encryption |
 | The service requires and runs as `root` | Every action is a `qm` command; no least-privilege mode exists |
 | `install.sh` is fetched over HTTPS and run unverified | Read it first, or install manually |

--- a/autoscale.py
+++ b/autoscale.py
@@ -7,7 +7,7 @@ import logging.config
 import time
 import re
 import sys
-from ssh_utils import SSHClient
+from ssh_utils import DEFAULT_KNOWN_HOSTS, SSHClient
 from pathlib import Path
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -163,6 +163,9 @@ class VMAutoscaler:
         # scaling cooldown survives between iterations of the main loop, and so
         # hotplug auto-configuration runs once per VM instead of every cycle.
         self._vm_managers: Dict[str, VMResourceManager] = {}
+        # Last observed running state per VM, so billing records transitions
+        # rather than one entry per poll.
+        self._vm_states: Dict[str, bool] = {}
         
         # Initialize billing tracker if enabled
         self.billing_enabled = self.config.get('billing', {}).get('enabled', False)
@@ -212,17 +215,21 @@ class VMAutoscaler:
         try:
             ssh_client = SSHClient(
                 host=host['host'],
-                port=host['ssh_port'],
+                port=host.get('ssh_port', 22),
                 user=host['ssh_user'],
                 password=host.get('ssh_password'),
-                key_path=host.get('ssh_key')
+                key_path=host.get('ssh_key'),
+                host_key_policy=self.config.get('ssh_host_key_policy', 'accept-new'),
+                known_hosts=self.config.get('ssh_known_hosts', DEFAULT_KNOWN_HOSTS),
             )
             ssh_client.connect()
 
             vm_manager = self._get_vm_manager(ssh_client, vm['vm_id'])
-            
+
             # First check if VM is running
-            if not vm_manager.is_vm_running():
+            running = vm_manager.is_vm_running()
+            self._record_vm_state(vm['vm_id'], running)
+            if not running:
                 self.logger.info(f"VM {vm['vm_id']} is not running. Skipping scaling.")
                 return
 
@@ -259,7 +266,10 @@ class VMAutoscaler:
                     )
                 else:
                     try:
-                        self._handle_cpu_scaling(vm_manager, vm['vm_id'], current_cpu_usage)
+                        self._handle_cpu_scaling(
+                            vm_manager, vm['vm_id'], current_cpu_usage,
+                            self._thresholds_for(vm, 'cpu'),
+                        )
                         self.logger.debug(f"CPU scaling completed for VM {vm['vm_id']}")
                     except Exception as e:
                         self.logger.error(f"CPU scaling failed for VM {vm['vm_id']}: {str(e)}")
@@ -273,7 +283,10 @@ class VMAutoscaler:
                     )
                 else:
                     try:
-                        self._handle_ram_scaling(vm_manager, vm['vm_id'], current_ram_usage)
+                        self._handle_ram_scaling(
+                            vm_manager, vm['vm_id'], current_ram_usage,
+                            self._thresholds_for(vm, 'ram'),
+                        )
                         self.logger.debug(f"RAM scaling completed for VM {vm['vm_id']}")
                     except Exception as e:
                         self.logger.error(f"RAM scaling failed for VM {vm['vm_id']}: {str(e)}")
@@ -307,17 +320,66 @@ class VMAutoscaler:
             manager.ensure_hotplug_configured()
         return manager
 
+    def _thresholds_for(self, vm: Dict[str, Any], resource: str) -> Dict[str, float]:
+        """Resolve the high/low thresholds for one VM and one resource.
+
+        Falls back to the global `scaling_thresholds` section. A VM may override
+        either or both bounds, in the flat shape shown in `config.yaml`:
+
+            thresholds:
+              cpu_high: 90
+              cpu_low: 30
+
+        or in the same nested shape as the global section:
+
+            thresholds:
+              cpu: { high: 90, low: 30 }
+
+        Both were previously ignored entirely - the block existed in the example
+        config but nothing read it.
+        """
+        thresholds = dict(self.config['scaling_thresholds'][resource])
+
+        overrides = vm.get('thresholds') or {}
+        if not isinstance(overrides, dict):
+            self.logger.warning(
+                f"VM {vm.get('vm_id')}: 'thresholds' is not a mapping; ignoring it."
+            )
+            return thresholds
+
+        nested = overrides.get(resource)
+        if isinstance(nested, dict):
+            for bound in ('high', 'low'):
+                if nested.get(bound) is not None:
+                    thresholds[bound] = nested[bound]
+
+        for bound in ('high', 'low'):
+            value = overrides.get(f"{resource}_{bound}")
+            if value is not None:
+                thresholds[bound] = value
+
+        if thresholds['low'] > thresholds['high']:
+            self.logger.warning(
+                f"VM {vm.get('vm_id')}: {resource} low threshold "
+                f"({thresholds['low']}) is above high ({thresholds['high']}); "
+                "using the global values instead."
+            )
+            return dict(self.config['scaling_thresholds'][resource])
+
+        return thresholds
+
     @staticmethod
     def _format_usage(value: Optional[float]) -> str:
         """Render a usage figure for the log, distinguishing unknown from zero."""
         return "unavailable" if value is None else f"{value:.2f}%"
 
     def _handle_cpu_scaling(self, vm_manager: VMResourceManager, vm_id: int,
-                            cpu_usage: Optional[float]) -> None:
+                            cpu_usage: Optional[float],
+                            thresholds: Optional[Dict[str, float]] = None) -> None:
         """Handle CPU scaling decisions. A None reading is never acted on."""
         if cpu_usage is None:
             return
-        thresholds = self.config['scaling_thresholds']['cpu']
+        thresholds = thresholds or self.config['scaling_thresholds']['cpu']
         if cpu_usage > thresholds['high']:
             if vm_manager.scale_cpu('up'):
                 self.notification_manager.send_notification(
@@ -338,11 +400,12 @@ class VMAutoscaler:
                     self._record_billing_spec(vm_manager, vm_id)
 
     def _handle_ram_scaling(self, vm_manager: VMResourceManager, vm_id: int,
-                            ram_usage: Optional[float]) -> None:
+                            ram_usage: Optional[float],
+                            thresholds: Optional[Dict[str, float]] = None) -> None:
         """Handle RAM scaling decisions. A None reading is never acted on."""
         if ram_usage is None:
             return
-        thresholds = self.config['scaling_thresholds']['ram']
+        thresholds = thresholds or self.config['scaling_thresholds']['ram']
         if ram_usage > thresholds['high']:
             if vm_manager.scale_ram('up'):
                 self.notification_manager.send_notification(
@@ -361,6 +424,65 @@ class VMAutoscaler:
                 # Record for billing
                 if self.billing_tracker:
                     self._record_billing_spec(vm_manager, vm_id)
+
+    def _record_vm_state(self, vm_id: Any, running: bool) -> None:
+        """Record a start/stop transition for billing.
+
+        Only transitions are written, so the state history stays proportional
+        to how often VMs actually change state rather than to the poll rate.
+        Nothing called this before, which is why every billing report showed
+        100% uptime.
+        """
+        if not self.billing_tracker:
+            return
+
+        key = str(vm_id)
+        if self._vm_states.get(key) == running:
+            return
+        self._vm_states[key] = running
+
+        try:
+            self.billing_tracker.record_vm_state_change(
+                key, 'started' if running else 'stopped'
+            )
+        except Exception as e:
+            self.logger.warning(f"Failed to record billing state for VM {vm_id}: {e}")
+
+    def _maybe_generate_billing_reports(self) -> None:
+        """Emit period reports once a full billing period has elapsed.
+
+        `generate_period_report` existed but nothing called it, so enabling
+        billing produced a growing state file and no CSV, no webhook and no
+        report of any kind.
+        """
+        if not self.billing_tracker:
+            return
+
+        try:
+            if not self.billing_tracker.is_period_due():
+                return
+        except Exception as e:
+            self.logger.error(f"Failed to check the billing period: {e}")
+            return
+
+        self.logger.info("Billing period elapsed; generating reports.")
+        generated = 0
+        for vm in self.config.get('virtual_machines', []):
+            try:
+                report = self.billing_tracker.generate_period_report(str(vm['vm_id']))
+                if report:
+                    generated += 1
+                    self.logger.info(
+                        f"Billing: VM {report.vm_id} cost {report.total_cost:.4f} "
+                        f"over {report.total_uptime_hours:.2f} uptime hours"
+                    )
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to generate a billing report for VM {vm.get('vm_id')}: {e}"
+                )
+
+        self.billing_tracker.set_last_report_time()
+        self.logger.info(f"Billing: generated {generated} report(s).")
 
     def _record_billing_spec(self, vm_manager: VMResourceManager, vm_id: int) -> None:
         """Record current VM spec for billing after a scaling operation."""
@@ -384,7 +506,9 @@ class VMAutoscaler:
                     for vm in self.config['virtual_machines']:
                         if vm['proxmox_host'] == host['name'] and vm.get('scaling_enabled', False):
                             self.process_vm(host, vm)
-                
+
+                self._maybe_generate_billing_reports()
+
                 check_interval = self.config.get('check_interval', 300)  # Default to 5 minutes
                 time.sleep(check_interval)
             

--- a/billing_tracker.py
+++ b/billing_tracker.py
@@ -106,6 +106,9 @@ class BillingTracker:
         self._spec_changes: Dict[str, List[SpecChangeRecord]] = {}
         self._state_changes: Dict[str, List[StateChangeRecord]] = {}
         self._vm_names: Dict[str, str] = {}
+        # When the last period report was emitted, so the service knows when
+        # the next one is due across restarts.
+        self._last_report_time: Optional[datetime] = None
         
         # Billing parameters
         self.cost_per_cpu_hour = self.billing_config.get('cost_per_cpu_core_per_hour', 0.01)
@@ -153,6 +156,11 @@ class BillingTracker:
                     ]
                 
                 self._vm_names = data.get('vm_names', {})
+
+                last_report = data.get('last_report_time')
+                if last_report:
+                    self._last_report_time = datetime.fromisoformat(last_report)
+
                 self.logger.debug(f"Loaded billing data from {data_file}")
             except Exception as e:
                 self.logger.warning(f"Failed to load billing data: {e}")
@@ -170,7 +178,10 @@ class BillingTracker:
                     vm_id: [r.to_dict() for r in records]
                     for vm_id, records in self._state_changes.items()
                 },
-                'vm_names': self._vm_names
+                'vm_names': self._vm_names,
+                'last_report_time': (
+                    self._last_report_time.isoformat() if self._last_report_time else None
+                ),
             }
             with open(data_file, 'w') as f:
                 json.dump(data, f, indent=2)
@@ -178,6 +189,27 @@ class BillingTracker:
         except Exception as e:
             self.logger.error(f"Failed to save billing data: {e}")
     
+    def get_last_report_time(self) -> Optional[datetime]:
+        """When the last period report was generated, or None if never."""
+        return self._last_report_time
+
+    def set_last_report_time(self, when: Optional[datetime] = None) -> None:
+        """Record that a period report has just been generated."""
+        self._last_report_time = when or datetime.now()
+        self._save_data()
+
+    def is_period_due(self, now: Optional[datetime] = None) -> bool:
+        """Whether a full billing period has elapsed since the last report.
+
+        The first call starts the clock rather than emitting an empty report
+        for a period the service was not running for.
+        """
+        now = now or datetime.now()
+        if self._last_report_time is None:
+            self.set_last_report_time(now)
+            return False
+        return (now - self._last_report_time) >= timedelta(days=self.billing_period_days)
+
     def set_vm_name(self, vm_id: str, vm_name: str) -> None:
         """Set the human-readable name for a VM."""
         self._vm_names[str(vm_id)] = vm_name
@@ -254,20 +286,24 @@ class BillingTracker:
         vm_id = str(vm_id)
         vm_name = self._vm_names.get(vm_id, f"VM-{vm_id}")
         
-        # Get records for this period
+        # Records that actually happened inside the period. These are what the
+        # report lists, because they are the real events.
         spec_records = [
             r for r in self._spec_changes.get(vm_id, [])
             if period_start <= r.timestamp <= period_end
         ]
-        state_records = [
-            r for r in self._state_changes.get(vm_id, [])
-            if period_start <= r.timestamp <= period_end
-        ]
-        
-        # Calculate CPU/RAM statistics
-        if spec_records:
-            cpu_values = [r.cpu_cores for r in spec_records]
-            ram_values = [r.ram_mb for r in spec_records]
+
+        # The series the period is *billed* from also carries in whatever was
+        # in effect at period_start. Without it, a VM that never changed spec
+        # during the period had no records at all and was billed zero.
+        effective_specs = self._specs_in_effect(vm_id, period_start, period_end)
+        state_records = self._states_in_effect(vm_id, period_start, period_end)
+
+        # Calculate CPU/RAM statistics over the specs actually in effect
+        if effective_specs:
+            spec_records_for_stats = effective_specs
+            cpu_values = [r.cpu_cores for r in spec_records_for_stats]
+            ram_values = [r.ram_mb for r in spec_records_for_stats]
             min_cpu = min(cpu_values)
             max_cpu = max(cpu_values)
             avg_cpu = sum(cpu_values) / len(cpu_values)
@@ -288,11 +324,11 @@ class BillingTracker:
         # Calculate cost (only charge for uptime)
         # Use time-weighted average for resources
         cpu_cost = self._calculate_resource_cost(
-            spec_records, 'cpu_cores', self.cost_per_cpu_hour, 
+            effective_specs, 'cpu_cores', self.cost_per_cpu_hour,
             period_start, period_end, state_records
         )
         ram_cost = self._calculate_resource_cost(
-            spec_records, 'ram_mb', self.cost_per_gb_ram_hour / 1024,  # Convert to per-MB
+            effective_specs, 'ram_mb', self.cost_per_gb_ram_hour / 1024,  # Convert to per-MB
             period_start, period_end, state_records
         )
         total_cost = cpu_cost + ram_cost
@@ -315,39 +351,90 @@ class BillingTracker:
             total_cost=total_cost
         )
     
-    def _calculate_uptime(self, state_records: List[StateChangeRecord],
-                          period_start: datetime, 
-                          period_end: datetime) -> tuple:
-        """Calculate total uptime and downtime hours for a period."""
+    def _specs_in_effect(self, vm_id: str, period_start: datetime,
+                         period_end: datetime) -> List[SpecChangeRecord]:
+        """Spec records covering the period, including the one carried in.
+
+        Spec changes are events, not samples: a VM that held one size for the
+        whole period produced no record inside it. Filtering strictly to the
+        period therefore billed such a VM zero. The last change before
+        `period_start` is replayed as an opening record at `period_start`.
+        """
+        records = sorted(self._spec_changes.get(vm_id, []), key=lambda r: r.timestamp)
+        inside = [r for r in records if period_start <= r.timestamp <= period_end]
+        before = [r for r in records if r.timestamp < period_start]
+
+        if not before:
+            return inside
+
+        carried = before[-1]
+        opening = SpecChangeRecord(
+            timestamp=period_start,
+            cpu_cores=carried.cpu_cores,
+            ram_mb=carried.ram_mb,
+        )
+        return [opening] + inside
+
+    def _states_in_effect(self, vm_id: str, period_start: datetime,
+                          period_end: datetime) -> List[StateChangeRecord]:
+        """State records for the period, including the state carried in.
+
+        Without the carry-in, a VM that started months ago and was stopped once
+        inside the period looked as though it had been down from `period_start`
+        until that stop.
+        """
+        records = sorted(self._state_changes.get(vm_id, []), key=lambda r: r.timestamp)
+        inside = [r for r in records if period_start <= r.timestamp <= period_end]
+        before = [r for r in records if r.timestamp < period_start]
+
+        if not before:
+            return inside
+
+        opening = StateChangeRecord(timestamp=period_start, state=before[-1].state)
+        return [opening] + inside
+
+    def _uptime_intervals(self, state_records: List[StateChangeRecord],
+                          period_start: datetime,
+                          period_end: datetime) -> List[tuple]:
+        """The (start, end) windows during which the VM was running."""
         if not state_records:
-            # Assume always up if no state records
-            total_hours = (period_end - period_start).total_seconds() / 3600
-            return total_hours, 0.0
-        
-        # Sort by timestamp
+            # Nothing recorded: assume the VM was up for the whole period.
+            return [(period_start, period_end)]
+
         sorted_records = sorted(state_records, key=lambda r: r.timestamp)
-        
-        uptime_seconds = 0
-        current_state = 'stopped'  # Assume stopped initially
+        intervals = []
+        current_state = 'stopped'
         last_timestamp = period_start
-        
+
         for record in sorted_records:
-            if current_state == 'started':
-                # Add time since last state change
-                uptime_seconds += (record.timestamp - last_timestamp).total_seconds()
-            
+            if current_state == 'started' and record.timestamp > last_timestamp:
+                intervals.append((last_timestamp, record.timestamp))
             current_state = record.state
             last_timestamp = record.timestamp
-        
-        # Account for time until period end
-        if current_state == 'started':
-            uptime_seconds += (period_end - last_timestamp).total_seconds()
-        
+
+        if current_state == 'started' and period_end > last_timestamp:
+            intervals.append((last_timestamp, period_end))
+
+        return intervals
+
+    def _calculate_uptime(self, state_records: List[StateChangeRecord],
+                          period_start: datetime,
+                          period_end: datetime) -> tuple:
+        """Calculate total uptime and downtime hours for a period."""
+        uptime_seconds = sum(
+            (end - start).total_seconds()
+            for start, end in self._uptime_intervals(state_records, period_start, period_end)
+        )
         total_seconds = (period_end - period_start).total_seconds()
-        uptime_hours = uptime_seconds / 3600
-        downtime_hours = (total_seconds - uptime_seconds) / 3600
-        
-        return uptime_hours, downtime_hours
+        return uptime_seconds / 3600, (total_seconds - uptime_seconds) / 3600
+
+    @staticmethod
+    def _overlap_seconds(a_start: datetime, a_end: datetime,
+                         b_start: datetime, b_end: datetime) -> float:
+        """Seconds shared by two intervals; zero when they do not overlap."""
+        start = max(a_start, b_start)
+        end = min(a_end, b_end)
+        return max(0.0, (end - start).total_seconds())
     
     def _calculate_resource_cost(self, spec_records: List[SpecChangeRecord],
                                   resource_key: str,
@@ -355,30 +442,37 @@ class BillingTracker:
                                   period_start: datetime,
                                   period_end: datetime,
                                   state_records: List[StateChangeRecord]) -> float:
-        """Calculate cost for a resource over the billing period."""
+        """Cost for one resource over the period, charged only while the VM was up.
+
+        `state_records` used to be accepted and ignored, so a VM powered off for
+        a week was still billed for that week at its last known spec.
+        """
         if not spec_records:
             return 0.0
-        
-        # Sort records by timestamp
+
+        up_intervals = self._uptime_intervals(state_records, period_start, period_end)
+        if not up_intervals:
+            return 0.0
+
         sorted_records = sorted(spec_records, key=lambda r: r.timestamp)
-        
+
         total_cost = 0.0
         last_record = sorted_records[0]
         last_timestamp = period_start
-        
-        for i, record in enumerate(sorted_records[1:], 1):
-            hours = (record.timestamp - last_timestamp).total_seconds() / 3600
-            resource_value = getattr(last_record, resource_key)
-            total_cost += resource_value * cost_per_unit_hour * hours
-            
+
+        def charge(spec, start, end):
+            billable = sum(
+                self._overlap_seconds(start, end, up_start, up_end)
+                for up_start, up_end in up_intervals
+            )
+            return getattr(spec, resource_key) * cost_per_unit_hour * (billable / 3600)
+
+        for record in sorted_records[1:]:
+            total_cost += charge(last_record, last_timestamp, record.timestamp)
             last_record = record
             last_timestamp = record.timestamp
-        
-        # Account for time until period end
-        hours = (period_end - last_timestamp).total_seconds() / 3600
-        resource_value = getattr(last_record, resource_key)
-        total_cost += resource_value * cost_per_unit_hour * hours
-        
+
+        total_cost += charge(last_record, last_timestamp, period_end)
         return total_cost
     
     def export_csv(self, report: BillingReport, 

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,8 @@ virtual_machines:
     scaling_enabled: true
     cpu_scaling: true    # Enable/disable CPU scaling
     ram_scaling: true    # Enable/disable RAM scaling
+    # Optional per-VM override of scaling_thresholds. Omit any bound to keep
+    # the global value. The nested shape (cpu: {high: 80, low: 20}) also works.
     thresholds:
       cpu_high: 80
       cpu_low: 20
@@ -57,6 +59,14 @@ virtual_machines:
       cpu_low: 20
       ram_high: 80
       ram_low: 20
+
+# SSH host key verification
+#   accept-new  trust a host the first time it is seen, record its key, and
+#               refuse to connect if that key ever changes (default)
+#   strict      only connect to hosts already listed in ssh_known_hosts
+#   auto        accept any key every time and never record it (no protection)
+ssh_host_key_policy: accept-new
+ssh_known_hosts: /etc/vm_autoscale/known_hosts
 
 # Logging configuration
 logging:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ pytest tests/test_vm_hotplug.py -v           # one file
 pytest -k cooldown -v                        # by name
 ```
 
-138 tests, under a second. CI runs them on Python 3.10 through 3.12, plus `shellcheck -S warning install.sh`.
+170 tests, under a second. CI runs them on Python 3.10 through 3.12, plus `shellcheck -S warning install.sh`.
 
 ## What a good change looks like
 
@@ -94,13 +94,12 @@ Pulled from [known limitations](/reference/limitations), roughly by value:
 
 | Area | What is needed |
 |---|---|
-| **Metric parsing** | Replace the `pvesh` table scrape with `--output-format json`. Removes a whole class of silent failure |
-| **Non-RSA SSH keys** | Load Ed25519 and ECDSA keys, not just RSA |
-| **Billing reporting** | Wire `generate_period_report` into the loop on a period boundary; make the cost calculation honour uptime |
-| **Per-VM thresholds** | The config already shows them; the code does not read them |
-| **Host key verification** | Replace the auto-add policy with something verifiable |
-| **Dry-run mode** | Log what would happen without issuing commands |
+| **Dry-run mode** | Log what would happen without issuing commands. The most requested missing safety net |
+| **Command result checking** | `qm set` failures are logged as successes because `execute_command` does not raise on a non-zero exit |
 | **Metrics endpoint** | Prometheus exposition for cycle count, decisions, failures |
+| **Per-VM scaling limits** | `scaling_limits` is global; thresholds are now per-VM but limits are not |
+| **Encrypted SSH keys** | A passphrase option, or ssh-agent support |
+| **Configurable step sizes** | Fixed at 1 core and 512 MB |
 
 ## Reporting bugs
 

--- a/docs/guide/billing.md
+++ b/docs/guide/billing.md
@@ -7,8 +7,8 @@ description: How Proxmox VM Autoscale records spec changes for usage-based billi
 
 If you resell Proxmox capacity, autoscaling turns a fixed monthly spec into a variable one, and you probably want to bill for what a customer actually consumed. The `BillingTracker` module records every spec change with a timestamp and can turn a period into a costed CSV report.
 
-::: warning Read this before you invoice anyone
-Only part of this feature is wired into the running service. Enabling `billing` records data; it does **not** produce reports on its own, and the cost calculation currently ignores downtime. The [what is automatic](#what-is-automatic-and-what-is-not) section is precise about the boundary. Reconcile against your own records before billing a customer.
+::: warning Reconcile before you invoice anyone
+Reports are generated from what the service observed. If it was down, restarted, or could not reach a node, those gaps are not in the data. Check the figures against your own records before billing a customer.
 :::
 
 ## Configuration
@@ -34,18 +34,20 @@ billing:
 | `webhook_script` | `""` | Executable receiving the report as JSON on stdin |
 | `webhook_url` | `""` | Endpoint receiving the report as a JSON `POST` |
 
-## What is automatic, and what is not
+## What the service does on its own
 
 | Capability | Automatic? |
 |---|---|
 | Recording a spec change after each successful scaling action | **Yes** |
-| Persisting records to `billing_data.json` | **Yes** |
-| Recording VM start/stop events | **No** — nothing in the service calls it |
-| Generating a CSV report | **No** — nothing in the service calls it |
-| Firing `webhook_script` / `webhook_url` | **No** — only reachable via report generation |
-| Setting a human-readable VM name | **No** |
+| Recording VM start/stop transitions | **Yes** |
+| Persisting everything to `billing_data.json` | **Yes** |
+| Generating a CSV report once a billing period elapses | **Yes** |
+| Firing `webhook_script` / `webhook_url` with that report | **Yes** |
+| Setting a human-readable VM name | No — call `set_vm_name` yourself |
 
-So with `enabled: true` you get a growing `billing_data.json` full of spec changes, and nothing else, until you invoke the reporting yourself. `record_vm_state_change`, `generate_period_report`, `export_csv`, `run_webhook` and `set_vm_name` are all public API — they are simply not called by `autoscale.py`. See [known limitations](/reference/limitations#billing-reports-are-not-generated-automatically).
+The period clock starts the first time the service runs with billing enabled, and is persisted, so it survives restarts. The first period therefore ends `billing_period_days` after you switched billing on, not on a calendar boundary.
+
+State transitions are recorded, not sampled: one entry when a VM stops, one when it starts again. A VM that stays up for a month adds a single record.
 
 ## The data file
 
@@ -79,9 +81,9 @@ sudo systemctl start vm_autoscale.service
 Timestamps are naive local time (`datetime.now()`), with no timezone and no DST handling. Reports spanning a DST boundary will be off by an hour.
 :::
 
-## Generating a report
+## Generating a report out of band
 
-Run this on the machine hosting the service, as a user who can read `csv_output_dir`:
+The service emits one automatically at the end of each period. To produce one on demand — a mid-period check, or a re-run after fixing a rate — run this on the machine hosting the service, as a user who can read `csv_output_dir`:
 
 ```python
 #!/usr/bin/env python3
@@ -137,11 +139,12 @@ cost = Σ (cores × cost_per_cpu_core_per_hour × hours_at_that_spec)
 
 The first recorded spec is treated as being in effect from `period_start`, and the last one runs to `period_end`.
 
-::: danger Downtime is billed as uptime
-The cost calculation does not consult the uptime records — and since nothing records VM state changes in the first place, uptime is reported as 100% regardless. A VM powered off for a week is billed for that week at its last known spec. This is a real defect, not a pricing policy; see [known limitations](/reference/limitations#downtime-is-billed-as-uptime).
-:::
+Cost is charged **only for the hours the VM was up**. A guest powered off for half the period pays for half of it, at whatever spec it held while running.
 
-Also: a VM that never scaled during a period has no spec records for it, and is billed **zero** — not "the spec it sat at the whole time". Usage-based billing here means *change*-based recording, so a customer on a stable spec produces no data.
+A VM that did not change spec during the period is still billed correctly: the last spec recorded before the period starts is carried in as the opening value. Earlier versions filtered strictly to the period and billed such a VM zero, which is the opposite of what a stable customer should see.
+
+::: tip Where the numbers can still be wrong
+The service bills from what it observed. If it was stopped for two days, those two days have no state records and are treated as uptime at the last known spec. Long outages of the autoscaler itself are worth reconciling by hand.
 
 ## Webhooks
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -61,7 +61,7 @@ Not through configuration. Step sizes are fixed at 1 core and 512 MB in `vm_mana
 
 ### Can I set different thresholds per VM?
 
-No. `config.yaml` shows a `thresholds:` block inside each VM entry, but the code reads only the global `scaling_thresholds`. The per-VM block is inert. See [known limitations](/reference/limitations#per-vm-thresholds-are-ignored).
+Yes. A `thresholds:` block inside a VM entry overrides the global `scaling_thresholds` for that VM, in either the flat shape (`cpu_high`, `cpu_low`, `ram_high`, `ram_low`) or the nested one (`cpu: { high, low }`). Override one bound or all four — anything you leave out keeps the global value. See the [configuration reference](/reference/configuration#virtual-machines).
 
 ### What happens if the service is restarted mid-cooldown?
 
@@ -113,7 +113,7 @@ No. If the service is running and a threshold is crossed, the command is execute
 
 ### Is it safe for production?
 
-It is a small single-process service with 138 unit tests, run by its author and by others across 302 stars and 23 forks. It is also alpha-versioned software that holds root credentials, has no dry-run, and has known defects documented on the [limitations](/reference/limitations) page. Read that page and the [threat model](/security/), pilot it on VMs you can afford to disturb, and decide for yourself.
+It is a small single-process service with 170 unit tests, run by its author and by others across 302 stars and 23 forks. It is also alpha-versioned software that holds root credentials, has no dry-run, and has known defects documented on the [limitations](/reference/limitations) page. Read that page and the [threat model](/security/), pilot it on VMs you can afford to disturb, and decide for yourself.
 
 ## Project
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -34,7 +34,6 @@ Being explicit about this saves a lot of disappointment:
 - **No disk, network or GPU scaling.** CPU cores, vCPUs and memory only.
 - **No prediction or trend analysis.** Decisions come from a single instantaneous sample per cycle. There is no smoothing, no moving average and no seasonality — a one-off spike between two polls is invisible, and a spike caught by a poll is acted on immediately.
 - **No dry-run mode.** If the service is running and a threshold is crossed, `qm set` is executed.
-- **No per-VM thresholds.** `config.yaml` shows a `thresholds:` block inside each VM entry, but the code reads only the global `scaling_thresholds`. See [known limitations](/reference/limitations#per-vm-thresholds-are-ignored).
 - **No high availability.** It is a single process. If it dies, systemd restarts it and the in-memory cooldown state starts over.
 
 ## Assumptions it makes

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,14 +14,16 @@ or 512 MB) per resource per cycle, bounded by configured limits and a
 per-resource cooldown. There is no dry-run mode.
 
 Key constraints a reader should know: the service authenticates to Proxmox
-nodes as root and holds those credentials in plain text in config.yaml; SSH
-host keys are accepted automatically without pinning; the SSH key must be
-unencrypted, though any key type works. Guest metrics come from
+nodes as root and holds those credentials in plain text in config.yaml. SSH
+host keys are verified — the default `accept-new` policy records a key on first
+contact and refuses to connect if it changes, and `strict` requires a
+pre-populated known_hosts — but the SSH key itself must be unencrypted, though
+any key type works. Guest metrics come from
 `pvesh get /cluster/resources --output-format json`; a metric that cannot be
 read is reported as unavailable and scaling is skipped for that cycle, never
-treated as zero. Per-VM thresholds shown in the example config are not read by
-the code. Billing records spec changes automatically but does not generate
-reports without being called explicitly.
+treated as zero. Thresholds can be overridden per VM; scaling limits cannot.
+Billing records spec changes and start/stop transitions, and emits a costed CSV
+once each billing period elapses, charging only for the hours a VM was up.
 
 ## Getting started
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -107,7 +107,7 @@ One method. Runs `pvesh get /nodes/$(hostname)/status --output-format json`, par
 
 ### `billing_tracker.py`
 
-Three dataclasses and a tracker. State is a single JSON file rewritten in full on every record. Reporting — period calculation, CSV export, webhooks — is complete API surface that the service does not currently call.
+Three dataclasses and a tracker. State is a single JSON file rewritten in full on every record. The main loop asks it once per cycle whether a billing period has elapsed and, when one has, generates a costed CSV per VM and fires any configured webhook.
 
 ## Threading and concurrency
 
@@ -156,7 +156,7 @@ Realistic places to add behaviour without restructuring:
 
 ## Tests
 
-`tests/` holds 138 unit tests across seven files, run with `pytest`. SSH is mocked throughout, so there is no integration test against a real Proxmox node — but metrics now come from `pvesh --output-format json`, and the tests exercise that parsing against realistic payloads rather than a scraped table.
+`tests/` holds 170 unit tests across eight files, run with `pytest`. SSH is mocked throughout, so there is no integration test against a real Proxmox node — but metrics now come from `pvesh --output-format json`, and the tests exercise that parsing against realistic payloads rather than a scraped table.
 
 ```bash
 python3 -m pytest tests/ -q

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -114,7 +114,7 @@ proxmox_hosts:
 | `ssh_user` | string | yes | Needs privileges to run `qm set` — in practice `root` |
 | `ssh_password` | string | one of the two | **Takes precedence over `ssh_key` when both are set** |
 | `ssh_key` | path | one of the two | Ed25519, ECDSA, RSA and DSS all supported. The key must be **unencrypted** — there is no passphrase option |
-| `ssh_port` | int | **yes** | There is no default in practice: `host['ssh_port']` is indexed directly rather than via `.get()`, so omitting the key raises `KeyError` and every VM on that host fails. Set it to `22` explicitly |
+| `ssh_port` | int | no | Defaults to `22`. Earlier versions indexed this key directly, so omitting it raised `KeyError` and every VM on that host failed |
 
 ::: warning Two footguns in the shipped example
 The example config fills in **both** `ssh_password` and `ssh_key` with placeholders. Password wins, so a half-edited config authenticates with the literal string `your_password_here`. Also, `host2` in the example omits `ssh_port` — and the code reads that key unconditionally, so the host raises a `KeyError`. Set `ssh_port` on every host.
@@ -140,7 +140,29 @@ virtual_machines:
 | `scaling_enabled` | bool | no | Defaults to `false` — omitting it means the VM is never processed |
 | `cpu_scaling` | bool | no | Defaults to `false` |
 | `ram_scaling` | bool | no | Defaults to `false` |
-| `thresholds` | map | — | **Ignored.** Present in the example config but never read |
+| `thresholds` | map | no | Per-VM overrides of `scaling_thresholds`. Flat (`cpu_high`, `cpu_low`, `ram_high`, `ram_low`) or nested (`cpu: { high, low }`). Any bound you omit keeps the global value |
+
+## SSH host key verification
+
+```yaml
+ssh_host_key_policy: accept-new
+ssh_known_hosts: /etc/vm_autoscale/known_hosts
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `ssh_host_key_policy` | string | `accept-new` | `accept-new`, `strict` or `auto` |
+| `ssh_known_hosts` | path | `/etc/vm_autoscale/known_hosts` | Created mode `600` in a `700` directory if absent |
+
+| Policy | Behaviour |
+|---|---|
+| `accept-new` | Trust a node the first time it is seen, record its key, and **refuse to connect if that key ever changes**. Equivalent to `ssh -o StrictHostKeyChecking=accept-new` |
+| `strict` | Only connect to nodes already listed in `ssh_known_hosts`. Pre-populate it with `ssh-keyscan` |
+| `auto` | Accept any key, every time, and record nothing. No protection whatsoever |
+
+::: warning `auto` was the old behaviour
+Before this was configurable the client used an auto-add policy with no known_hosts file loaded or saved, so every connection accepted whatever key it was offered. `auto` reproduces that and exists only as an escape hatch. A host key mismatch under the other two policies is fatal and is **not** retried — see the [hardening guide](/security/hardening#verify-ssh-host-keys).
+:::
 
 ## `host_limits`
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -31,31 +31,7 @@ is logged whether or not `qm set` succeeded, and whether or not the guest honour
 
 **Workaround:** verify with `qm config <vmid>` when a change matters.
 
-### Per-VM `thresholds` are ignored
-
-`config.yaml` shows a `thresholds:` block inside each `virtual_machines` entry. Nothing reads it — only the global `scaling_thresholds` is consulted.
-
-**Impact:** you may believe a VM has bespoke thresholds when it does not.
-
-**Workaround:** run a second instance with its own config for a VM that genuinely needs different numbers.
-
-### Downtime is billed as uptime
-
-`BillingTracker._calculate_resource_cost` accepts the uptime records and never uses them, despite an in-code comment saying cost is charged for uptime only. Compounding this, nothing in the service calls `record_vm_state_change`, so there are no uptime records to begin with — every report shows 100% uptime.
-
-**Impact:** a VM powered off for a week is billed for that week at its last known spec.
-
-**Workaround:** reconcile against your own uptime source before invoicing.
-
 ## Documented-but-absent behaviour
-
-### Billing reports are not generated automatically
-
-Enabling `billing` wires up exactly one thing: recording a spec change after each successful scaling action. `generate_period_report`, `export_csv`, `run_webhook`, `record_vm_state_change` and `set_vm_name` are public API that nothing calls.
-
-**Impact:** no CSV appears, no webhook fires, no uptime is tracked.
-
-**Workaround:** the [billing page](/guide/billing#generating-a-report) has a script that calls the API on a schedule.
 
 ### `logging` in `config.yaml` is inert by default
 
@@ -89,12 +65,6 @@ Fixed at 1 core and 512 MB per action, in `vm_manager.py`. Recovering from a lar
 
 One process, no leader election, no shared state. Two instances managing the same VM will fight, since neither sees the other's cooldowns.
 
-### `ssh_port` is read unconditionally
-
-`host['ssh_port']` is indexed directly rather than via `.get()`, so a host entry without that key raises `KeyError` and every VM on it fails. The shipped example config omits it on `host2`.
-
-**Workaround:** set `ssh_port` on every host.
-
 ### `ssh_password` silently overrides `ssh_key`
 
 When both are present the password is used. The shipped example fills in both with placeholders.
@@ -109,11 +79,11 @@ Ed25519, ECDSA, RSA and DSS key types all load, but there is no passphrase optio
 
 **Workaround:** protect the key with file permissions and a `from=` restriction in `authorized_keys` instead.
 
-### SSH host keys are accepted automatically
+### Host key trust is first-use, not pre-shared
 
-The client uses an auto-add policy: any host key is trusted on first contact and no pinning is performed. An attacker positioned between the service and a node can present their own key and receive your root credentials.
+The default `accept-new` policy records a node's host key the first time it is seen and refuses to connect if that key later changes. That closes the window on everything after the first connection, but the first connection itself is still trust-on-first-use: an attacker already in position at that moment would be recorded as legitimate.
 
-**Workaround:** the [hardening guide](/security/hardening#pin-ssh-host-keys) shows how to constrain this at the network and configuration level.
+**Workaround:** pre-populate `ssh_known_hosts` with `ssh-keyscan` before the first run and set `ssh_host_key_policy: strict`. See the [hardening guide](/security/hardening#verify-ssh-host-keys).
 
 ### Credentials are stored in plain text
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -24,8 +24,11 @@ VMAutoscaler(config_path: str, logging_config_path: Optional[str] = None)
 | `_load_config` | `(config_path: str) -> dict` | Static. Raises `FileNotFoundError` or `ConfigurationError` |
 | `_setup_logging` | `(path: Optional[str]) -> Logger` | JSON config wins over the YAML `logging` section |
 | `_get_vm_manager` | `(ssh_client, vm_id) -> VMResourceManager` | Cached per VMID; rebinds the SSH client |
-| `_handle_cpu_scaling` | `(vm_manager, vm_id, cpu_usage: float) -> None` | |
-| `_handle_ram_scaling` | `(vm_manager, vm_id, ram_usage: float) -> None` | |
+| `_handle_cpu_scaling` | `(vm_manager, vm_id, cpu_usage, thresholds=None) -> None` | Ignores a `None` reading |
+| `_handle_ram_scaling` | `(vm_manager, vm_id, ram_usage, thresholds=None) -> None` | Ignores a `None` reading |
+| `_thresholds_for` | `(vm: dict, resource: str) -> dict` | Per-VM overrides on top of the global thresholds |
+| `_record_vm_state` | `(vm_id, running: bool) -> None` | Writes a billing record on transitions only |
+| `_maybe_generate_billing_reports` | `() -> None` | Emits period reports when due |
 | `_record_billing_spec` | `(vm_manager, vm_id) -> None` | No-op when billing is disabled |
 
 ### `class NotificationManager`
@@ -90,7 +93,8 @@ Failing getters return conservative defaults — `1` core, `512` MB — rather t
 ### `class SSHClient`
 
 ```python
-SSHClient(host, user, password=None, key_path=None, port=22)
+SSHClient(host, user, password=None, key_path=None, port=22,
+          host_key_policy="accept-new", known_hosts="/etc/vm_autoscale/known_hosts")
 ```
 
 | Method | Signature | Notes |
@@ -99,6 +103,7 @@ SSHClient(host, user, password=None, key_path=None, port=22)
 | `execute_command` | `(command: str, timeout=30) -> tuple[str, str, int]` | `(stdout, stderr, exit_status)`. Retries with reconnect; **does not raise on non-zero exit** |
 | `close` | `() -> None` | Idempotent |
 | `_load_private_key` | `() -> paramiko.PKey` | Any supported key type; raises `SSHException` naming the path on failure |
+| `_apply_host_key_policy` | `(client) -> None` | Applies `accept-new` / `strict` / `auto` and loads `known_hosts` |
 | `is_connected` | `() -> bool` | |
 | `__enter__` / `__exit__` | | Context-manager support |
 
@@ -130,14 +135,18 @@ Creates `csv_output_dir` and loads `billing_data.json` on construction.
 
 | Method | Signature | Called by the service? |
 |---|---|---|
-| `record_spec_change` | `(vm_id, cpu_cores, ram_mb, timestamp=None) -> None` | **Yes** |
-| `record_vm_state_change` | `(vm_id, state: "started" \| "stopped", timestamp=None) -> None` | No |
-| `set_vm_name` | `(vm_id, vm_name) -> None` | No |
-| `calculate_billing_period` | `(vm_id, period_start, period_end) -> BillingReport` | No |
-| `export_csv` | `(report, output_path=None) -> str` | No |
-| `run_webhook` | `(report) -> None` | No |
-| `generate_period_report` | `(vm_id) -> Optional[BillingReport]` | No |
+| `record_spec_change` | `(vm_id, cpu_cores, ram_mb, timestamp=None) -> None` | **Yes**, after each scaling action |
+| `record_vm_state_change` | `(vm_id, state: "started" \| "stopped", timestamp=None) -> None` | **Yes**, on transitions only |
+| `is_period_due` | `(now=None) -> bool` | **Yes**, once per cycle; the first call starts the clock |
+| `generate_period_report` | `(vm_id) -> Optional[BillingReport]` | **Yes**, when a period elapses |
+| `get_last_report_time` / `set_last_report_time` | | **Yes** |
+| `calculate_billing_period` | `(vm_id, period_start, period_end) -> BillingReport` | Via `generate_period_report` |
+| `export_csv` | `(report, output_path=None) -> str` | Via `generate_period_report` |
+| `run_webhook` | `(report) -> None` | Via `generate_period_report` |
+| `set_vm_name` | `(vm_id, vm_name) -> None` | No — call it yourself |
 
+Costs are charged only for the hours a VM was up, and the spec in effect at
+`period_start` is carried in so a VM that never changed size is still billed.
 Every write persists the entire state file. See [billing](/guide/billing).
 
 ### Dataclasses

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -73,20 +73,64 @@ from="10.0.0.5",no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-pty 
 
 A forced command is tempting but impractical here, since the service issues several different commands with variable arguments. A wrapper script that whitelists `qm status|config|set` and `pvesh get` for specific VMIDs is possible if you want to invest in it.
 
-## Pin SSH host keys
+## Verify SSH host keys
 
-The client trusts any host key it is offered and does not pin. You cannot change that from configuration, so mitigate around it:
+The default is `accept-new`: the service records each node's host key the first
+time it connects and refuses to connect if that key later changes.
+
+```yaml
+ssh_host_key_policy: accept-new
+ssh_known_hosts: /etc/vm_autoscale/known_hosts
+```
+
+That leaves one window open — the first connection is trust-on-first-use. To
+close it, pin the keys yourself and switch to `strict`:
+
+```bash
+sudo install -d -m 700 /etc/vm_autoscale
+for h in 10.0.0.11 10.0.0.12; do
+    ssh-keyscan -H "$h" | sudo tee -a /etc/vm_autoscale/known_hosts
+done
+sudo chmod 600 /etc/vm_autoscale/known_hosts
+```
+
+::: warning Verify the fingerprints out of band
+`ssh-keyscan` trusts whatever answers. Compare what it collected against the
+fingerprints printed on each node's console:
+
+```bash
+# On the Proxmox node
+ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
+```
+:::
+
+```yaml
+ssh_host_key_policy: strict
+```
+
+Under `strict` a node missing from `ssh_known_hosts` is refused, so remember to
+add new nodes before adding them to `proxmox_hosts`.
+
+A mismatch is fatal and is not retried:
+
+```
+[ERROR] Host key mismatch for 10.0.0.11: the server presented a key that does
+        not match the one recorded in /etc/vm_autoscale/known_hosts.
+```
+
+If a node was legitimately rebuilt, remove its line from the file. Otherwise
+investigate before doing anything else — that message is what an interception
+attempt looks like.
+
+Still worth doing alongside:
 
 - **Segment the network.** Put management SSH on a dedicated VLAN reachable only from the autoscaler.
 - **Use addresses, not names.** `host: 10.0.0.11` removes DNS from the attack path.
-- **Pre-populate `known_hosts`** so at least an interactive `ssh` from that box fails loudly if a key changes:
 
-  ```bash
-  ssh-keyscan -H 10.0.0.11 | sudo tee -a /root/.ssh/known_hosts
-  ```
-
-  The service will not consult it, but it gives you a tripwire.
-- **Alert on host key changes** with a periodic `ssh-keyscan` diff.
+::: danger `ssh_host_key_policy: auto` disables all of this
+It reproduces the old behaviour — accept any key, every time, remember nothing.
+It exists as an escape hatch and logs a warning on every connection.
+:::
 
 ## Confine the systemd unit
 
@@ -236,6 +280,7 @@ Rotate immediately if `config.yaml` was ever readable by a non-root user, if the
 - [ ] `config.yaml` is `600`, root-owned
 - [ ] `/etc/vm_autoscale` is `700`, backup inside is `600`
 - [ ] Key authentication, dedicated key, `ssh_password` removed
+- [ ] `ssh_host_key_policy: strict` with a verified `ssh_known_hosts`
 - [ ] `from=` restriction on the key in `authorized_keys`
 - [ ] Management SSH on a segmented network
 - [ ] systemd hardening drop-in applied and verified

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -39,9 +39,11 @@ After the fix, `config.yaml` is mode `600` and root-owned. What remains readable
 
 ### Network attacker between the service and a node
 
-The SSH client uses an **auto-add host key policy**: any host key presented is trusted, and no pinning is performed on subsequent connections. An attacker able to intercept or redirect the connection can present their own key and receive the root password or complete a key-based handshake against their own server.
+Host keys are now verified. Under the default `accept-new` policy the service records a node's key on first contact and **refuses to connect if it later changes**, so an attacker who interposes after that first connection is blocked and logged rather than handed root credentials.
 
-This is the most serious design-level exposure. It is inherent to the current implementation, not a misconfiguration. Mitigate at the network layer — see [hardening](/security/hardening#pin-ssh-host-keys).
+What remains is the first connection itself: trust-on-first-use means an attacker already in position at that moment is recorded as legitimate. Set `ssh_host_key_policy: strict` and pre-populate `ssh_known_hosts` with `ssh-keyscan` to close that too — see [hardening](/security/hardening#verify-ssh-host-keys).
+
+Before this was configurable the client accepted any key on every connection and remembered nothing, which offered no protection at all. `ssh_host_key_policy: auto` reproduces that behaviour if you need it.
 
 ### Root on the autoscaler host
 
@@ -69,7 +71,7 @@ These are properties of how the service works. They are not going to be fixed by
 |---|---|---|
 | **Root SSH required** | Every action is a `qm` command | Not today; there is no least-privilege mode |
 | **Credentials in plain text** | No secrets backend | File permissions and disk encryption only |
-| **Auto-add host keys** | Paramiko `AutoAddPolicy` | Network segmentation, dedicated management VLAN |
+| **First-use host key trust** | `accept-new` records a key on first contact | `strict` plus a pre-populated `ssh_known_hosts` |
 | **Service runs unconfined as root** | Shipped unit sets `User=root` with no sandboxing | Yes — [systemd drop-in](/security/hardening#confine-the-systemd-unit) |
 | **VMIDs interpolated into shell strings** | No validation on `vm_id` | Config is admin-controlled, so not remotely exploitable |
 | **No audit trail beyond the log** | No structured events | Ship the log somewhere append-only |

--- a/ssh_utils.py
+++ b/ssh_utils.py
@@ -1,10 +1,30 @@
-import paramiko
 import logging
+import os
 import time
-from paramiko.ssh_exception import SSHException, AuthenticationException
+
+import paramiko
+from paramiko.ssh_exception import (
+    AuthenticationException,
+    BadHostKeyException,
+    SSHException,
+)
+
+DEFAULT_KNOWN_HOSTS = "/etc/vm_autoscale/known_hosts"
+
+#: Host key policies, loosest last.
+#:
+#: ``accept-new``  trust a host the first time it is seen, record its key, and
+#:                 refuse to connect if that key ever changes. This is what
+#:                 ``ssh -o StrictHostKeyChecking=accept-new`` does.
+#: ``strict``      only connect to hosts already present in known_hosts.
+#: ``auto``        accept any key, every time, and never record it. This was
+#:                 the previous behaviour and offers no protection at all.
+HOST_KEY_POLICIES = ("accept-new", "strict", "auto")
+
 
 class SSHClient:
-    def __init__(self, host, user, password=None, key_path=None, port=22):
+    def __init__(self, host, user, password=None, key_path=None, port=22,
+                 host_key_policy="accept-new", known_hosts=DEFAULT_KNOWN_HOSTS):
         """
         Initializes the SSH client with given credentials.
         :param host: Hostname or IP address of the server.
@@ -12,17 +32,72 @@ class SSHClient:
         :param password: Password for SSH (optional).
         :param key_path: Path to the private SSH key (optional).
         :param port: Port for SSH connection (default: 22).
+        :param host_key_policy: One of "accept-new", "strict" or "auto".
+        :param known_hosts: Path to the known_hosts file used for verification.
         """
         self.host = host
         self.user = user
         self.password = password
         self.key_path = key_path
         self.port = port
+        self.host_key_policy = (host_key_policy or "accept-new").lower()
+        self.known_hosts = known_hosts
         self.logger = logging.getLogger("ssh_utils")
         self.client = None
         # Added max retries and backoff factor for connection attempts
         self.max_retries = 5
         self.backoff_factor = 1
+
+        if self.host_key_policy not in HOST_KEY_POLICIES:
+            raise ValueError(
+                f"Unknown ssh_host_key_policy {host_key_policy!r}; "
+                f"expected one of {', '.join(HOST_KEY_POLICIES)}"
+            )
+
+    def _apply_host_key_policy(self, client):
+        """Configure host key verification on a fresh paramiko client.
+
+        The previous implementation set AutoAddPolicy without ever loading or
+        saving a known_hosts file, so every connection accepted whatever key it
+        was offered and nothing was remembered between connections - no
+        protection against an attacker sitting between the service and a node
+        holding root credentials.
+        """
+        if self.host_key_policy == "auto":
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.logger.warning(
+                f"Host key verification is disabled for {self.host} "
+                "(ssh_host_key_policy: auto). Any key will be accepted."
+            )
+            return
+
+        try:
+            client.load_system_host_keys()
+        except Exception as e:
+            self.logger.debug(f"Could not load system host keys: {e}")
+
+        if self.known_hosts:
+            directory = os.path.dirname(self.known_hosts)
+            try:
+                if directory:
+                    os.makedirs(directory, mode=0o700, exist_ok=True)
+                if not os.path.exists(self.known_hosts):
+                    # Create it so paramiko has somewhere to persist new keys.
+                    with open(self.known_hosts, "a"):
+                        pass
+                    os.chmod(self.known_hosts, 0o600)
+                client.load_host_keys(self.known_hosts)
+            except OSError as e:
+                self.logger.warning(
+                    f"Could not use known_hosts file {self.known_hosts}: {e}. "
+                    "Host keys learned during this run will not be remembered."
+                )
+
+        if self.host_key_policy == "strict":
+            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+        else:
+            # accept-new: record an unknown key, reject a changed one.
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     def connect(self):
         """
@@ -36,7 +111,7 @@ class SSHClient:
         while attempt < self.max_retries:
             try:
                 self.client = paramiko.SSHClient()
-                self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                self._apply_host_key_policy(self.client)
                 
                 # Connect using password or private key
                 if self.password:
@@ -62,6 +137,15 @@ class SSHClient:
                 self.logger.info(f"Successfully connected to {self.host} on port {self.port}")
                 break  # successful connection: exit loop
 
+            except BadHostKeyException as e:
+                self.logger.error(
+                    f"Host key mismatch for {self.host}: the server presented a key "
+                    f"that does not match the one recorded in {self.known_hosts}. "
+                    "Refusing to connect. If the host was legitimately rebuilt, "
+                    "remove its entry from that file; otherwise investigate before "
+                    "doing anything else."
+                )
+                raise
             except AuthenticationException:
                 self.logger.error(f"Authentication failed for {self.host}. Check credentials or key file.")
                 raise

--- a/tests/test_thresholds_hostkeys_billing.py
+++ b/tests/test_thresholds_hostkeys_billing.py
@@ -1,0 +1,386 @@
+"""
+Regression tests for three defects fixed together.
+
+1. `virtual_machines[].thresholds` appeared in the example config but nothing
+   read it; every VM used the global `scaling_thresholds`.
+2. SSH used `AutoAddPolicy` with no known_hosts file loaded or saved, so every
+   connection accepted whatever key it was offered and remembered nothing.
+3. Billing never recorded VM state changes, never generated a report, billed
+   downtime as uptime, and billed a VM that had not changed spec during the
+   period as zero.
+"""
+
+import json
+import logging
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import paramiko
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from autoscale import VMAutoscaler
+from billing_tracker import BillingTracker, SpecChangeRecord, StateChangeRecord
+from ssh_utils import SSHClient
+
+
+def make_logger():
+    logger = logging.getLogger("test")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+
+def bare_autoscaler(config):
+    with patch.object(VMAutoscaler, "__init__", lambda s, *a, **kw: None):
+        a = VMAutoscaler.__new__(VMAutoscaler)
+    a.config = config
+    a.logger = make_logger()
+    a.notification_manager = MagicMock()
+    a.billing_tracker = None
+    a._vm_managers = {}
+    a._vm_states = {}
+    return a
+
+
+GLOBAL_THRESHOLDS = {
+    "cpu": {"high": 80, "low": 20},
+    "ram": {"high": 85, "low": 25},
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-VM thresholds
+# ---------------------------------------------------------------------------
+
+class TestPerVMThresholds(unittest.TestCase):
+
+    def _autoscaler(self):
+        return bare_autoscaler({"scaling_thresholds": GLOBAL_THRESHOLDS})
+
+    def test_falls_back_to_the_global_thresholds(self):
+        a = self._autoscaler()
+        self.assertEqual(a._thresholds_for({"vm_id": 101}, "cpu"), {"high": 80, "low": 20})
+        self.assertEqual(a._thresholds_for({"vm_id": 101}, "ram"), {"high": 85, "low": 25})
+
+    def test_flat_override_shape_from_the_example_config(self):
+        a = self._autoscaler()
+        vm = {"vm_id": 101, "thresholds": {"cpu_high": 95, "cpu_low": 40,
+                                           "ram_high": 70, "ram_low": 10}}
+        self.assertEqual(a._thresholds_for(vm, "cpu"), {"high": 95, "low": 40})
+        self.assertEqual(a._thresholds_for(vm, "ram"), {"high": 70, "low": 10})
+
+    def test_nested_override_shape(self):
+        a = self._autoscaler()
+        vm = {"vm_id": 101, "thresholds": {"cpu": {"high": 95, "low": 40}}}
+        self.assertEqual(a._thresholds_for(vm, "cpu"), {"high": 95, "low": 40})
+
+    def test_a_partial_override_keeps_the_global_value_for_the_other_bound(self):
+        a = self._autoscaler()
+        vm = {"vm_id": 101, "thresholds": {"cpu_high": 95}}
+        self.assertEqual(a._thresholds_for(vm, "cpu"), {"high": 95, "low": 20})
+
+    def test_overrides_do_not_leak_between_vms(self):
+        a = self._autoscaler()
+        a._thresholds_for({"vm_id": 101, "thresholds": {"cpu_high": 95}}, "cpu")
+        self.assertEqual(a._thresholds_for({"vm_id": 102}, "cpu"), {"high": 80, "low": 20})
+
+    def test_inverted_bounds_fall_back_to_global(self):
+        a = self._autoscaler()
+        vm = {"vm_id": 101, "thresholds": {"cpu_high": 10, "cpu_low": 90}}
+        self.assertEqual(a._thresholds_for(vm, "cpu"), {"high": 80, "low": 20})
+
+    def test_non_mapping_thresholds_are_ignored(self):
+        a = self._autoscaler()
+        self.assertEqual(
+            a._thresholds_for({"vm_id": 101, "thresholds": "nonsense"}, "cpu"),
+            {"high": 80, "low": 20},
+        )
+
+    def test_handler_uses_the_per_vm_threshold(self):
+        """55% is idle for a VM whose low mark is 60, and normal for one at 20."""
+        a = self._autoscaler()
+
+        strict = MagicMock()
+        a._handle_cpu_scaling(strict, 101, 55.0, {"high": 90, "low": 60})
+        strict.scale_cpu.assert_called_once_with("down")
+
+        relaxed = MagicMock()
+        a._handle_cpu_scaling(relaxed, 102, 55.0, {"high": 80, "low": 20})
+        relaxed.scale_cpu.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Host key verification
+# ---------------------------------------------------------------------------
+
+class TestHostKeyPolicy(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.known_hosts = os.path.join(self.tmp.name, "known_hosts")
+
+    def client(self, policy="accept-new"):
+        return SSHClient(host="10.0.0.11", user="root", password="x",
+                         host_key_policy=policy, known_hosts=self.known_hosts)
+
+    def test_rejects_an_unknown_policy_name(self):
+        with self.assertRaises(ValueError):
+            SSHClient(host="h", user="root", password="x", host_key_policy="whatever")
+
+    def test_accept_new_loads_and_creates_the_known_hosts_file(self):
+        fake = MagicMock()
+        self.client("accept-new")._apply_host_key_policy(fake)
+        self.assertTrue(os.path.exists(self.known_hosts))
+        fake.load_host_keys.assert_called_once_with(self.known_hosts)
+        policy = fake.set_missing_host_key_policy.call_args.args[0]
+        self.assertIsInstance(policy, paramiko.AutoAddPolicy)
+
+    def test_known_hosts_file_is_not_world_readable(self):
+        self.client("accept-new")._apply_host_key_policy(MagicMock())
+        self.assertEqual(os.stat(self.known_hosts).st_mode & 0o077, 0)
+
+    def test_strict_uses_reject_policy(self):
+        fake = MagicMock()
+        self.client("strict")._apply_host_key_policy(fake)
+        policy = fake.set_missing_host_key_policy.call_args.args[0]
+        self.assertIsInstance(policy, paramiko.RejectPolicy)
+        fake.load_host_keys.assert_called_once_with(self.known_hosts)
+
+    def test_auto_keeps_the_old_behaviour_and_loads_nothing(self):
+        fake = MagicMock()
+        self.client("auto")._apply_host_key_policy(fake)
+        policy = fake.set_missing_host_key_policy.call_args.args[0]
+        self.assertIsInstance(policy, paramiko.AutoAddPolicy)
+        fake.load_host_keys.assert_not_called()
+
+    def test_default_policy_is_accept_new_not_blind_acceptance(self):
+        client = SSHClient(host="10.0.0.11", user="root", password="x")
+        self.assertEqual(client.host_key_policy, "accept-new")
+
+    def test_unwritable_known_hosts_degrades_instead_of_crashing(self):
+        client = SSHClient(host="10.0.0.11", user="root", password="x",
+                           known_hosts="/proc/definitely/not/writable/known_hosts")
+        fake = MagicMock()
+        client._apply_host_key_policy(fake)   # must not raise
+        fake.set_missing_host_key_policy.assert_called_once()
+
+    def test_a_changed_host_key_is_fatal_and_not_retried(self):
+        client = self.client("accept-new")
+        client.max_retries = 5
+        bad = paramiko.ssh_exception.BadHostKeyException(
+            "10.0.0.11", MagicMock(), MagicMock()
+        )
+        with patch("paramiko.SSHClient") as fake_cls:
+            fake_cls.return_value.connect.side_effect = bad
+            with self.assertRaises(paramiko.ssh_exception.BadHostKeyException):
+                client.connect()
+            # One attempt only: a swapped host key is not a transient fault.
+            self.assertEqual(fake_cls.return_value.connect.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# 3. Billing
+# ---------------------------------------------------------------------------
+
+class BillingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def tracker(self, **billing):
+        config = {"billing": {"enabled": True, "csv_output_dir": self.tmp.name,
+                              "cost_per_cpu_core_per_hour": 1.0,
+                              "cost_per_gb_ram_per_hour": 0.0, **billing}}
+        return BillingTracker(config, make_logger())
+
+
+class TestDowntimeIsNotBilled(BillingTestCase):
+
+    def test_a_vm_stopped_for_half_the_period_is_billed_half(self):
+        t = self.tracker()
+        start = datetime(2026, 1, 1)
+        end = start + timedelta(hours=10)
+
+        t.record_spec_change("101", cpu_cores=2, ram_mb=0, timestamp=start)
+        t.record_vm_state_change("101", "started", timestamp=start)
+        t.record_vm_state_change("101", "stopped", timestamp=start + timedelta(hours=5))
+
+        report = t.calculate_billing_period("101", start, end)
+        # 2 cores x 1.0/hour x 5 up hours
+        self.assertAlmostEqual(report.total_cost, 10.0)
+        self.assertAlmostEqual(report.total_uptime_hours, 5.0)
+        self.assertAlmostEqual(report.total_downtime_hours, 5.0)
+
+    def test_a_vm_up_the_whole_period_is_billed_in_full(self):
+        t = self.tracker()
+        start = datetime(2026, 1, 1)
+        end = start + timedelta(hours=10)
+
+        t.record_spec_change("101", cpu_cores=2, ram_mb=0, timestamp=start)
+        t.record_vm_state_change("101", "started", timestamp=start)
+
+        report = t.calculate_billing_period("101", start, end)
+        self.assertAlmostEqual(report.total_cost, 20.0)
+        self.assertAlmostEqual(report.uptime_percentage, 100.0)
+
+    def test_a_vm_never_started_is_billed_nothing(self):
+        t = self.tracker()
+        start = datetime(2026, 1, 1)
+        end = start + timedelta(hours=10)
+
+        t.record_spec_change("101", cpu_cores=8, ram_mb=0, timestamp=start)
+        t.record_vm_state_change("101", "stopped", timestamp=start)
+
+        report = t.calculate_billing_period("101", start, end)
+        self.assertAlmostEqual(report.total_cost, 0.0)
+        self.assertAlmostEqual(report.total_uptime_hours, 0.0)
+
+
+class TestPeriodCarriesStateIn(BillingTestCase):
+
+    def test_a_vm_that_never_changed_spec_is_still_billed(self):
+        """Spec changes are events; a stable VM produces none inside a period."""
+        t = self.tracker()
+        t.record_spec_change("101", cpu_cores=4, ram_mb=0,
+                             timestamp=datetime(2025, 12, 1))
+
+        start = datetime(2026, 1, 1)
+        end = start + timedelta(hours=10)
+        report = t.calculate_billing_period("101", start, end)
+
+        self.assertAlmostEqual(report.total_cost, 40.0)
+        self.assertEqual(report.min_cpu_cores, 4)
+        self.assertEqual(report.max_cpu_cores, 4)
+
+    def test_a_running_state_from_before_the_period_carries_in(self):
+        t = self.tracker()
+        t.record_spec_change("101", cpu_cores=1, ram_mb=0, timestamp=datetime(2025, 12, 1))
+        t.record_vm_state_change("101", "started", timestamp=datetime(2025, 12, 1))
+
+        start = datetime(2026, 1, 1)
+        end = start + timedelta(hours=10)
+        t.record_vm_state_change("101", "stopped", timestamp=start + timedelta(hours=8))
+
+        report = t.calculate_billing_period("101", start, end)
+        # Up for the first 8 hours, not down for them.
+        self.assertAlmostEqual(report.total_uptime_hours, 8.0)
+        self.assertAlmostEqual(report.total_cost, 8.0)
+
+    def test_the_report_lists_only_events_inside_the_period(self):
+        t = self.tracker()
+        t.record_spec_change("101", cpu_cores=1, ram_mb=0, timestamp=datetime(2025, 12, 1))
+        start = datetime(2026, 1, 1)
+        t.record_spec_change("101", cpu_cores=2, ram_mb=0,
+                             timestamp=start + timedelta(hours=1))
+
+        report = t.calculate_billing_period("101", start, start + timedelta(hours=10))
+        self.assertEqual(len(report.spec_changes), 1)
+        self.assertEqual(report.spec_changes[0]["cpu_cores"], 2)
+
+
+class TestReportSchedule(BillingTestCase):
+
+    def test_the_first_check_starts_the_clock_without_reporting(self):
+        t = self.tracker(billing_period_days=30)
+        self.assertIsNone(t.get_last_report_time())
+        self.assertFalse(t.is_period_due())
+        self.assertIsNotNone(t.get_last_report_time())
+
+    def test_not_due_before_the_period_elapses(self):
+        t = self.tracker(billing_period_days=30)
+        t.set_last_report_time(datetime.now() - timedelta(days=29))
+        self.assertFalse(t.is_period_due())
+
+    def test_due_once_the_period_has_elapsed(self):
+        t = self.tracker(billing_period_days=30)
+        t.set_last_report_time(datetime.now() - timedelta(days=31))
+        self.assertTrue(t.is_period_due())
+
+    def test_the_clock_survives_a_restart(self):
+        t = self.tracker(billing_period_days=30)
+        stamp = datetime.now() - timedelta(days=10)
+        t.set_last_report_time(stamp)
+
+        reloaded = self.tracker(billing_period_days=30)
+        self.assertEqual(reloaded.get_last_report_time(), stamp)
+
+    def test_the_timestamp_is_persisted_to_the_data_file(self):
+        t = self.tracker()
+        t.set_last_report_time(datetime(2026, 1, 1, 12, 0))
+        with open(os.path.join(self.tmp.name, "billing_data.json")) as fh:
+            self.assertEqual(json.load(fh)["last_report_time"], "2026-01-01T12:00:00")
+
+
+class TestAutoscalerDrivesBilling(BillingTestCase):
+
+    def _autoscaler(self, tracker):
+        a = bare_autoscaler({
+            "scaling_thresholds": GLOBAL_THRESHOLDS,
+            "virtual_machines": [{"vm_id": "101"}, {"vm_id": "102"}],
+        })
+        a.billing_tracker = tracker
+        return a
+
+    def test_state_transitions_are_recorded_once_each(self):
+        t = MagicMock()
+        a = self._autoscaler(t)
+
+        a._record_vm_state("101", True)
+        a._record_vm_state("101", True)     # unchanged: no second record
+        a._record_vm_state("101", False)
+
+        self.assertEqual(
+            [c.args for c in t.record_vm_state_change.call_args_list],
+            [("101", "started"), ("101", "stopped")],
+        )
+
+    def test_nothing_is_recorded_when_billing_is_disabled(self):
+        a = bare_autoscaler({"scaling_thresholds": GLOBAL_THRESHOLDS})
+        a._record_vm_state("101", True)     # must not raise
+
+    def test_reports_are_generated_when_the_period_is_due(self):
+        t = MagicMock()
+        t.is_period_due.return_value = True
+        t.generate_period_report.return_value = MagicMock(
+            vm_id="101", total_cost=1.0, total_uptime_hours=1.0
+        )
+        a = self._autoscaler(t)
+
+        a._maybe_generate_billing_reports()
+
+        self.assertEqual(t.generate_period_report.call_count, 2)
+        t.set_last_report_time.assert_called_once()
+
+    def test_no_reports_before_the_period_is_due(self):
+        t = MagicMock()
+        t.is_period_due.return_value = False
+        a = self._autoscaler(t)
+
+        a._maybe_generate_billing_reports()
+
+        t.generate_period_report.assert_not_called()
+        t.set_last_report_time.assert_not_called()
+
+    def test_one_failing_vm_does_not_stop_the_others(self):
+        t = MagicMock()
+        t.is_period_due.return_value = True
+        t.generate_period_report.side_effect = [
+            RuntimeError("disk full"),
+            MagicMock(vm_id="102", total_cost=1.0, total_uptime_hours=1.0),
+        ]
+        a = self._autoscaler(t)
+
+        a._maybe_generate_billing_reports()
+
+        self.assertEqual(t.generate_period_report.call_count, 2)
+        t.set_last_report_time.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three documented features that were inert or wrong, plus one `KeyError` in the same code path.

> [!IMPORTANT]
> **Two behaviour changes on upgrade.**
> - A `thresholds:` block in a VM entry now **takes effect**. If you wrote one expecting it to work, it starts working — check the numbers before upgrading.
> - Host keys are now verified (`accept-new`). The first connection to each node records its key; a later change is **refused**. If you rebuild a node, remove its line from `ssh_known_hosts`.

## 1. Per-VM `thresholds` were never read

`config.yaml` has shown this since the beginning:

```yaml
virtual_machines:
  - vm_id: "101"
    thresholds:
      cpu_high: 80
      cpu_low: 20
```

Nothing consulted it. Every VM used the global `scaling_thresholds`.

Both shapes work now — the flat one above, and the nested one matching the global section (`cpu: { high, low }`). Any bound you omit keeps the global value. Inverted bounds (`low` above `high`) fall back to the global pair with a warning rather than producing a VM that scales both ways at once.

## 2. Host keys were not verified at all

The client set `AutoAddPolicy` **without ever loading or saving a known_hosts file**. Every connection accepted whatever key it was offered, and nothing was remembered between connections — because a fresh `paramiko.SSHClient` is built each time. For a service that authenticates as `root` on hypervisors, that is no protection whatsoever.

```yaml
ssh_host_key_policy: accept-new              # default
ssh_known_hosts: /etc/vm_autoscale/known_hosts
```

| Policy | Behaviour |
|---|---|
| `accept-new` | Record the key on first contact; **refuse to connect if it changes** |
| `strict` | Only connect to nodes already in `ssh_known_hosts` |
| `auto` | The old behaviour. Warns on every connection |

A mismatch is fatal and is **not** retried — a swapped host key is not a transient fault:

```
[ERROR] Host key mismatch for 10.0.0.11: the server presented a key that does not
        match the one recorded in /etc/vm_autoscale/known_hosts. Refusing to connect.
```

`accept-new` is the default rather than `strict` so existing deployments keep working: the first connection after upgrade records the key, everything after it is verified.

## 3. Billing recorded data and produced nothing

Enabling `billing` wired up exactly one thing: a spec record after each scaling action. `generate_period_report`, `record_vm_state_change`, `export_csv` and `run_webhook` were public API that nothing called — so no CSV, no webhook, and every report claiming 100% uptime.

The arithmetic was wrong in two further ways:

- **Downtime was billed as uptime.** `_calculate_resource_cost` accepted the uptime records and ignored them, despite a comment saying cost is charged for uptime only. A VM powered off for a week was billed for that week at its last known spec.
- **A stable VM was billed zero.** Spec changes are *events*, not samples. A guest that held one size for the whole period had no records inside it, so filtering strictly to the period produced no cost at all — exactly backwards for the customer who never needed scaling.

Fixed: the loop records start/stop **transitions** (not one entry per poll) and emits a costed report per VM once a period elapses, with the clock persisted so it survives restarts. Cost is charged only for hours the VM was running, and the spec and running state in effect at `period_start` are carried in.

## 4. `ssh_port` took down every VM on a host

Indexed directly rather than via `.get()`, so omitting it raised `KeyError` — and the shipped example config omits it on `host2`. It has a default of `22` again.

## Verification

- **170 tests**, 32 new. **30 of them fail against `main`.**
- Host key tests cover all three policies, the known_hosts file being created `600`, an unwritable path degrading instead of crashing, and a mismatch raising after exactly **one** attempt.
- Billing tests assert a VM stopped for half a period costs half, a VM never started costs nothing, a VM that never changed spec is still billed, and a running state from before the period carries in.

## Documentation

Four entries leave [known limitations](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/limitations.html) — the page is down to genuine constraints. The billing guide, threat model, hardening guide, configuration and module references, FAQ, `llms.txt` and `SECURITY.md` are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)