### PR TITLE
feat: dry-run mode, Prometheus metrics, per-VM limits; detect failed commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ listener. The whole service is one blocking loop over SSH.
 | `host_resource_checker.py` | The host headroom gate, from `pvesh get /nodes/<n>/status` |
 | `ssh_utils.py` | Paramiko wrapper: connect with backoff, execute, close |
 | `billing_tracker.py` | Spec-change recording and costed period reports |
+| `metrics.py` | Prometheus registry and a daemon-thread HTTP endpoint |
 
 ## The cycle
 
@@ -83,7 +84,7 @@ them. The only durable state the service writes is the billing JSON file.
 
 ## Tests
 
-170 unit tests in `tests/`, run with `pytest`. SSH is mocked throughout, so
+201 unit tests in `tests/`, run with `pytest`. SSH is mocked throughout, so
 anything depending on real `pvesh` output format is not covered by CI.
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dry-run mode** (`dry_run: true`). Everything is evaluated and nothing is
+  changed: no command that touches a VM is issued, hotplug auto-configuration
+  included. Reads still happen, so the evaluation is real; the cooldown still
+  applies, so the cadence in the log is the cadence you would get.
+  Notifications carry a `[DRY RUN]` prefix and billing records nothing.
+- **Prometheus metrics endpoint** (`metrics.enabled`), off by default and
+  localhost-bound when on. Exports cycle count and duration, per-VM CPU/RAM,
+  running state and errors, scaling actions by resource and direction, scaling
+  failures, per-node utilisation and gate blocks. A metric that could not be
+  read has its series **removed** rather than reported as zero. Standard
+  library only — no new dependency.
+- **Per-VM `scaling_limits`.** A VM entry may override any of the global
+  limits, so a 2-core web server and a 16-core database can share one instance.
+  Resolution: the VM's own block, then the global section, then the legacy flat
+  keys, then the built-in default.
+- `tests/test_dryrun_metrics_limits.py`: 31 regression tests (201 total).
+
+### Fixed
+- **A failed `qm set` is no longer reported as a success.** `execute_command`
+  returns the exit status rather than raising, and every caller discarded it,
+  so a command that exited non-zero still produced
+  `Increased cores to 5 (hotplug applied)` in the log, a success notification,
+  a billing record and a consumed cooldown — which then delayed the retry by a
+  full `scale_cooldown`. Commands now run through a checked helper that raises
+  `CommandFailed` with the command, the exit status and stderr.
+- **A failed `qm config` read no longer invents a value.** The getters returned
+  1 core, 1 vCPU or 512 MB when the command failed, and those fabricated
+  numbers went straight into a scaling decision — the service would happily
+  "scale up from 1 core" a guest that actually had eight. They now raise. An
+  *absent* key still means the documented Proxmox default, because that is what
+  absence legitimately means.
+- **A missing VM is no longer retried for 30 seconds.** `qm status` exiting
+  non-zero was treated as a transient fault and retried three times with
+  backoff. It now fails fast and logs stderr.
+
 ## [1.5.0] - 2026-09-05
 
 > **Upgrade note.** Three behaviour changes land together:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ With hotplug and NUMA enabled on a guest, vCPU and balloon memory changes apply 
 - **No LXC containers** — see [proxmox-lxc-autoscale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale)
 - **No disk, network or GPU scaling** — CPU cores, vCPUs and memory only
 - **No prediction** — one instantaneous sample per cycle, no smoothing or trend analysis
-- **No dry-run mode** — if a threshold is crossed, `qm set` runs
 
 ## Requirements
 
@@ -93,6 +92,31 @@ Gotify and SMTP notifications, billing tracking and hotplug auto-configuration a
 
 > [!WARNING]
 > `config.yaml` holds your Proxmox SSH credentials in plain text. It must be root-owned and mode `600` — the installer does this. See the [hardening guide](https://fabriziosalmi.github.io/proxmox-vm-autoscale/security/hardening.html).
+
+## Try it without letting it act
+
+```yaml
+dry_run: true
+```
+
+Everything is evaluated and nothing is changed: no `qm set` is issued, the log records what would have happened, and notifications carry a `[DRY RUN]` prefix.
+
+```
+[dry-run] VM 101: would run `qm set 101 -vcpus 3`
+```
+
+## Monitoring
+
+An optional Prometheus endpoint, off by default and bound to localhost when on:
+
+```yaml
+metrics:
+  enabled: true
+  bind: 127.0.0.1
+  port: 9808
+```
+
+Exports cycle count and duration, per-VM CPU/RAM and running state, scaling actions by resource and direction, failures, and per-node utilisation. A metric that could not be read is **absent** rather than zero.
 
 ## Documentation
 

--- a/autoscale.py
+++ b/autoscale.py
@@ -14,6 +14,7 @@ from email.mime.multipart import MIMEMultipart
 from vm_manager import VMResourceManager
 from host_resource_checker import HostResourceChecker
 from billing_tracker import BillingTracker
+from metrics import MetricsServer, build_registry
 from functools import wraps
 from typing import Union, List, Optional, Dict, Any
 
@@ -129,6 +130,8 @@ class NotificationManager:
         sent = False
         errors = []
         formatted_message = self._format_message(message)
+        if self.config.get('dry_run', False):
+            formatted_message = f"[DRY RUN] {formatted_message}"
 
         if self.config.get('gotify', {}).get('enabled', False):
             try:
@@ -166,6 +169,16 @@ class VMAutoscaler:
         # Last observed running state per VM, so billing records transitions
         # rather than one entry per poll.
         self._vm_states: Dict[str, bool] = {}
+        self.dry_run = bool(self.config.get('dry_run', False))
+        self.metrics = build_registry()
+        self.metrics.set('vm_autoscale_build_info', 1,
+                         {'dry_run': str(self.dry_run).lower()})
+        self._metrics_server = self._start_metrics_server()
+        if self.dry_run:
+            self.logger.warning(
+                "DRY RUN: no command that changes a VM will be issued. "
+                "Scaling decisions are logged as they would be taken."
+            )
         
         # Initialize billing tracker if enabled
         self.billing_enabled = self.config.get('billing', {}).get('enabled', False)
@@ -224,10 +237,12 @@ class VMAutoscaler:
             )
             ssh_client.connect()
 
-            vm_manager = self._get_vm_manager(ssh_client, vm['vm_id'])
+            vm_manager = self._get_vm_manager(ssh_client, vm)
 
             # First check if VM is running
             running = vm_manager.is_vm_running()
+            self.metrics.set('vm_autoscale_vm_running', 1 if running else 0,
+                             {'vm_id': str(vm['vm_id'])})
             self._record_vm_state(vm['vm_id'], running)
             if not running:
                 self.logger.info(f"VM {vm['vm_id']} is not running. Skipping scaling.")
@@ -235,9 +250,13 @@ class VMAutoscaler:
 
             # Check host resources first
             host_checker = HostResourceChecker(ssh_client)
-            if not host_checker.check_host_resources(
-                    self.config['host_limits']['max_host_cpu_percent'],
-                    self.config['host_limits']['max_host_ram_percent']):
+            within_limits = host_checker.check_host_resources(
+                self.config['host_limits']['max_host_cpu_percent'],
+                self.config['host_limits']['max_host_ram_percent'])
+            self._record_host_metrics(host['name'], host_checker)
+            if not within_limits:
+                self.metrics.inc('vm_autoscale_host_gate_blocked_total',
+                                 {'host': host['name']})
                 self.logger.warning(f"Host {host['name']} resources maxed out. Skipping scaling.")
                 return
 
@@ -250,6 +269,8 @@ class VMAutoscaler:
                 f"CPU: {self._format_usage(current_cpu_usage)}, "
                 f"RAM: {self._format_usage(current_ram_usage)}"
             )
+
+            self._record_usage_metrics(vm['vm_id'], current_cpu_usage, current_ram_usage)
 
             if current_cpu_usage is None and current_ram_usage is None:
                 self.logger.warning(
@@ -272,6 +293,8 @@ class VMAutoscaler:
                         )
                         self.logger.debug(f"CPU scaling completed for VM {vm['vm_id']}")
                     except Exception as e:
+                        self.metrics.inc('vm_autoscale_scaling_failures_total',
+                                         {'vm_id': str(vm['vm_id']), 'resource': 'cpu'})
                         self.logger.error(f"CPU scaling failed for VM {vm['vm_id']}: {str(e)}")
                         # Continue to RAM scaling even if CPU scaling fails
 
@@ -289,9 +312,12 @@ class VMAutoscaler:
                         )
                         self.logger.debug(f"RAM scaling completed for VM {vm['vm_id']}")
                     except Exception as e:
+                        self.metrics.inc('vm_autoscale_scaling_failures_total',
+                                         {'vm_id': str(vm['vm_id']), 'resource': 'ram'})
                         self.logger.error(f"RAM scaling failed for VM {vm['vm_id']}: {str(e)}")
 
         except Exception as e:
+            self.metrics.inc('vm_autoscale_vm_errors_total', {'vm_id': str(vm['vm_id'])})
             self.logger.error(f"Error processing VM {vm['vm_id']} on host {host['name']}: {e}")
             self.notification_manager.send_notification(
                 f"Error processing VM {vm['vm_id']} on host {host['name']}: {e}",
@@ -301,17 +327,41 @@ class VMAutoscaler:
             if ssh_client:
                 ssh_client.close()
 
-    def _get_vm_manager(self, ssh_client: SSHClient, vm_id: Any) -> VMResourceManager:
-        """Return the VMResourceManager for `vm_id`, creating it on first use.
+    def _start_metrics_server(self) -> Optional[MetricsServer]:
+        """Start the Prometheus endpoint when it is enabled in the config.
 
-        A fresh SSH connection is opened every cycle, so the cached manager is
-        rebound to the current client. Keeping the manager itself alive is what
-        makes `scale_cooldown` meaningful across cycles.
+        Off by default, and bound to localhost when on: this process holds root
+        credentials, and the series it exposes name your nodes and VMIDs with
+        no authentication in front of them.
         """
+        cfg = self.config.get('metrics') or {}
+        if not cfg.get('enabled', False):
+            return None
+
+        server = MetricsServer(
+            self.metrics, self.logger,
+            bind=cfg.get('bind', '127.0.0.1'),
+            port=int(cfg.get('port', 9808)),
+            path=cfg.get('path', '/metrics'),
+        )
+        return server if server.start() else None
+
+    def _get_vm_manager(self, ssh_client: SSHClient,
+                        vm: Any) -> VMResourceManager:
+        """Return the VMResourceManager for a VM, creating it on first use.
+
+        Accepts either the VM's config entry or a bare id. A fresh SSH
+        connection is opened every cycle, so the cached manager is rebound to
+        the current client. Keeping the manager itself alive is what makes
+        `scale_cooldown` meaningful across cycles.
+        """
+        vm_config = vm if isinstance(vm, dict) else {}
+        vm_id = vm['vm_id'] if isinstance(vm, dict) else vm
+
         key = str(vm_id)
         manager = self._vm_managers.get(key)
         if manager is None:
-            manager = VMResourceManager(ssh_client, vm_id, self.config)
+            manager = VMResourceManager(ssh_client, vm_id, self.config, vm_config)
             self._vm_managers[key] = manager
         else:
             manager.ssh_client = ssh_client
@@ -368,6 +418,35 @@ class VMAutoscaler:
 
         return thresholds
 
+    def _record_host_metrics(self, host_name: str, checker: HostResourceChecker) -> None:
+        """Publish the node readings the gate just used."""
+        if checker.last_cpu_percent is not None:
+            self.metrics.set('vm_autoscale_host_cpu_percent',
+                             checker.last_cpu_percent, {'host': host_name})
+        if checker.last_ram_percent is not None:
+            self.metrics.set('vm_autoscale_host_ram_percent',
+                             checker.last_ram_percent, {'host': host_name})
+
+    def _record_usage_metrics(self, vm_id: Any, cpu: Optional[float],
+                              ram: Optional[float]) -> None:
+        """Publish guest usage, dropping the series when it is unreadable.
+
+        An absent series is not the same as a zero one. Emitting 0 for a metric
+        that could not be read would put the same lie into your dashboards that
+        it used to put into the scaling decision.
+        """
+        labels = {'vm_id': str(vm_id)}
+        for name, value, resource in (
+            ('vm_autoscale_vm_cpu_percent', cpu, 'cpu'),
+            ('vm_autoscale_vm_ram_percent', ram, 'ram'),
+        ):
+            if value is None:
+                self.metrics.unset(name, labels)
+                self.metrics.inc('vm_autoscale_metric_unavailable_total',
+                                 {'vm_id': str(vm_id), 'resource': resource})
+            else:
+                self.metrics.set(name, value, labels)
+
     @staticmethod
     def _format_usage(value: Optional[float]) -> str:
         """Render a usage figure for the log, distinguishing unknown from zero."""
@@ -382,6 +461,9 @@ class VMAutoscaler:
         thresholds = thresholds or self.config['scaling_thresholds']['cpu']
         if cpu_usage > thresholds['high']:
             if vm_manager.scale_cpu('up'):
+                self.metrics.inc('vm_autoscale_scaling_actions_total',
+                                 {'vm_id': str(vm_id), 'resource': 'cpu',
+                                  'direction': 'up'})
                 self.notification_manager.send_notification(
                     f"Scaled up CPU for VM {vm_id} due to high usage ({cpu_usage}%).",
                     priority=7
@@ -391,6 +473,9 @@ class VMAutoscaler:
                     self._record_billing_spec(vm_manager, vm_id)
         elif cpu_usage < thresholds['low']:
             if vm_manager.scale_cpu('down'):
+                self.metrics.inc('vm_autoscale_scaling_actions_total',
+                                 {'vm_id': str(vm_id), 'resource': 'cpu',
+                                  'direction': 'down'})
                 self.notification_manager.send_notification(
                     f"Scaled down CPU for VM {vm_id} due to low usage ({cpu_usage}%).",
                     priority=5
@@ -408,6 +493,9 @@ class VMAutoscaler:
         thresholds = thresholds or self.config['scaling_thresholds']['ram']
         if ram_usage > thresholds['high']:
             if vm_manager.scale_ram('up'):
+                self.metrics.inc('vm_autoscale_scaling_actions_total',
+                                 {'vm_id': str(vm_id), 'resource': 'ram',
+                                  'direction': 'up'})
                 self.notification_manager.send_notification(
                     f"Scaled up RAM for VM {vm_id} due to high usage ({ram_usage}%).",
                     priority=7
@@ -417,6 +505,9 @@ class VMAutoscaler:
                     self._record_billing_spec(vm_manager, vm_id)
         elif ram_usage < thresholds['low']:
             if vm_manager.scale_ram('down'):
+                self.metrics.inc('vm_autoscale_scaling_actions_total',
+                                 {'vm_id': str(vm_id), 'resource': 'ram',
+                                  'direction': 'down'})
                 self.notification_manager.send_notification(
                     f"Scaled down RAM for VM {vm_id} due to low usage ({ram_usage}%).",
                     priority=5
@@ -433,7 +524,7 @@ class VMAutoscaler:
         Nothing called this before, which is why every billing report showed
         100% uptime.
         """
-        if not self.billing_tracker:
+        if not self.billing_tracker or self.dry_run:
             return
 
         key = str(vm_id)
@@ -455,7 +546,7 @@ class VMAutoscaler:
         billing produced a growing state file and no CSV, no webhook and no
         report of any kind.
         """
-        if not self.billing_tracker:
+        if not self.billing_tracker or self.dry_run:
             return
 
         try:
@@ -486,6 +577,9 @@ class VMAutoscaler:
 
     def _record_billing_spec(self, vm_manager: VMResourceManager, vm_id: int) -> None:
         """Record current VM spec for billing after a scaling operation."""
+        if self.dry_run:
+            # Nothing was changed, so there is no new spec to bill for.
+            return
         try:
             current_cores = vm_manager._get_current_cores()
             current_ram = vm_manager._get_current_ram()
@@ -502,12 +596,18 @@ class VMAutoscaler:
         self.logger.info("Starting VM Autoscaler")
         while True:
             try:
+                cycle_started = time.monotonic()
                 for host in self.config['proxmox_hosts']:
                     for vm in self.config['virtual_machines']:
                         if vm['proxmox_host'] == host['name'] and vm.get('scaling_enabled', False):
                             self.process_vm(host, vm)
 
                 self._maybe_generate_billing_reports()
+
+                self.metrics.inc('vm_autoscale_cycles_total')
+                self.metrics.set('vm_autoscale_cycle_duration_seconds',
+                                 time.monotonic() - cycle_started)
+                self.metrics.set('vm_autoscale_last_cycle_timestamp_seconds', time.time())
 
                 check_interval = self.config.get('check_interval', 300)  # Default to 5 minutes
                 time.sleep(check_interval)
@@ -516,6 +616,7 @@ class VMAutoscaler:
                 self.logger.info("Shutting down VM Autoscaler")
                 break
             except Exception as e:
+                self.metrics.inc('vm_autoscale_cycle_errors_total')
                 self.logger.error(f"Unexpected error in main loop: {e}")
                 self.notification_manager.send_notification(
                     f"Unexpected error in VM Autoscaler: {e}",

--- a/config.yaml
+++ b/config.yaml
@@ -54,11 +54,30 @@ virtual_machines:
     scaling_enabled: true
     cpu_scaling: true
     ram_scaling: true
+    # Optional per-VM override of the global scaling_limits. Same keys; any
+    # you omit fall back to the global value.
+    scaling_limits:
+      max_cores: 16
+      max_ram_mb: 32768
     thresholds:
       cpu_high: 80
       cpu_low: 20
       ram_high: 80
       ram_low: 20
+
+# Dry run: evaluate everything and change nothing. No `qm set` is issued; the
+# log records what would have happened, and notifications are prefixed
+# [DRY RUN]. Billing records nothing, since nothing changed.
+dry_run: false
+
+# Prometheus metrics endpoint (optional).
+# Off by default and bound to localhost when on: this service holds root
+# credentials, the series name your nodes and VMIDs, and there is no auth.
+metrics:
+  enabled: false
+  bind: 127.0.0.1
+  port: 9808
+  path: /metrics
 
 # SSH host key verification
 #   accept-new  trust a host the first time it is seen, record its key, and

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ pytest tests/test_vm_hotplug.py -v           # one file
 pytest -k cooldown -v                        # by name
 ```
 
-170 tests, under a second. CI runs them on Python 3.10 through 3.12, plus `shellcheck -S warning install.sh`.
+201 tests, under a second. CI runs them on Python 3.10 through 3.12, plus `shellcheck -S warning install.sh`.
 
 ## What a good change looks like
 
@@ -94,12 +94,11 @@ Pulled from [known limitations](/reference/limitations), roughly by value:
 
 | Area | What is needed |
 |---|---|
-| **Dry-run mode** | Log what would happen without issuing commands. The most requested missing safety net |
-| **Command result checking** | `qm set` failures are logged as successes because `execute_command` does not raise on a non-zero exit |
-| **Metrics endpoint** | Prometheus exposition for cycle count, decisions, failures |
-| **Per-VM scaling limits** | `scaling_limits` is global; thresholds are now per-VM but limits are not |
+| **Guest-side verification** | `qm set` failures are caught now, but QEMU accepting a command is not the guest honouring it |
+| **Per-node host limits** | `host_limits` is still one pair of numbers for every node |
 | **Encrypted SSH keys** | A passphrase option, or ssh-agent support |
 | **Configurable step sizes** | Fixed at 1 core and 512 MB |
+| **Smoothing** | One instantaneous sample per cycle; a moving average would cut flapping |
 
 ## Reporting bugs
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -109,11 +109,11 @@ Realistically, the two risks are memory and CPU removal. Ballooning memory away 
 
 ### Is there a dry-run mode?
 
-No. If the service is running and a threshold is crossed, the command is executed. The nearest approximation is `scaling_enabled: false` on every VM, which produces the monitoring log lines with no actions.
+Yes — `dry_run: true`. Everything is evaluated and nothing is changed: no `qm set` is issued, the log records what would have happened, notifications carry a `[DRY RUN]` prefix, and billing records nothing because nothing changed. It is the right way to start on a fleet you did not build yourself.
 
 ### Is it safe for production?
 
-It is a small single-process service with 170 unit tests, run by its author and by others across 302 stars and 23 forks. It is also alpha-versioned software that holds root credentials, has no dry-run, and has known defects documented on the [limitations](/reference/limitations) page. Read that page and the [threat model](/security/), pilot it on VMs you can afford to disturb, and decide for yourself.
+It is a small single-process service with 201 unit tests, run by its author and by others across 302 stars and 23 forks. It holds root credentials and has known constraints documented on the [limitations](/reference/limitations) page. Read that page and the [threat model](/security/), pilot it on VMs you can afford to disturb, and decide for yourself.
 
 ## Project
 

--- a/docs/guide/host-limits.md
+++ b/docs/guide/host-limits.md
@@ -58,7 +58,9 @@ Both are required keys — there is no default. A missing `host_limits` section 
 
 ## Multi-node behaviour
 
-Limits are global, not per host: the same two numbers apply to every node in `proxmox_hosts`. If one node is much smaller or much busier than the rest, you cannot express that today. The workaround is to run a second instance of the service with its own config file and its own systemd unit.
+`host_limits` is global, not per host: the same two numbers apply to every node in `proxmox_hosts`. If one node is much smaller or much busier than the rest, you cannot express that today — run a second instance with its own config and unit.
+
+(Per-VM *scaling* limits are supported; it is the per-node ceilings that are still global. See [configuration](/reference/configuration#virtual-machines).)
 
 ## What is not checked
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,7 +33,6 @@ Being explicit about this saves a lot of disappointment:
 - **No LXC containers.** Use the sibling project [proxmox-lxc-autoscale](https://github.com/fabriziosalmi/proxmox-lxc-autoscale) for those.
 - **No disk, network or GPU scaling.** CPU cores, vCPUs and memory only.
 - **No prediction or trend analysis.** Decisions come from a single instantaneous sample per cycle. There is no smoothing, no moving average and no seasonality — a one-off spike between two polls is invisible, and a spike caught by a poll is acted on immediately.
-- **No dry-run mode.** If the service is running and a threshold is crossed, `qm set` is executed.
 - **No high availability.** It is a single process. If it dies, systemd restarts it and the in-memory cooldown state starts over.
 
 ## Assumptions it makes

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -142,9 +142,103 @@ Per resource:
 
 Everything at once: `systemctl stop vm_autoscale.service`.
 
-## Monitoring the autoscaler itself
+## Dry run
 
-The service exposes no metrics endpoint and no health check. Practical options:
+```yaml
+dry_run: true
+```
+
+Everything is evaluated and nothing is changed. No command that touches a VM is
+issued — including hotplug auto-configuration — the log records what would have
+happened, notifications carry a `[DRY RUN]` prefix, and billing records nothing,
+because nothing changed.
+
+```
+[WARNING] DRY RUN: no command that changes a VM will be issued.
+[INFO]    VM 101 current usage - CPU: 91.20%, RAM: 44.10%
+[INFO]    [dry-run] VM 101: would run `qm set 101 -vcpus 3`
+```
+
+Reads still happen, so what you see is a real evaluation against real usage,
+and the cooldown still applies — the cadence in the log is the cadence you
+would get. This is the right way to start on a fleet you did not build.
+
+## Metrics
+
+An optional Prometheus endpoint, **off by default** and bound to localhost when
+enabled:
+
+```yaml
+metrics:
+  enabled: true
+  bind: 127.0.0.1
+  port: 9808
+  path: /metrics
+```
+
+::: danger It has no authentication
+The series name your nodes and VMIDs and report their utilisation, and this
+process holds root credentials for your hypervisors. Leave it on `127.0.0.1`
+and let your scraper reach it over a tunnel, or put a reverse proxy that
+authenticates in front of it. A bind failure is logged and the service carries
+on without it.
+:::
+
+```bash
+curl -s http://127.0.0.1:9808/metrics
+```
+
+| Metric | Type | Labels |
+|---|---|---|
+| `vm_autoscale_up` | gauge | |
+| `vm_autoscale_build_info` | gauge | `dry_run` |
+| `vm_autoscale_cycles_total` | counter | |
+| `vm_autoscale_cycle_duration_seconds` | gauge | |
+| `vm_autoscale_last_cycle_timestamp_seconds` | gauge | |
+| `vm_autoscale_cycle_errors_total` | counter | |
+| `vm_autoscale_vm_running` | gauge | `vm_id` |
+| `vm_autoscale_vm_cpu_percent` | gauge | `vm_id` |
+| `vm_autoscale_vm_ram_percent` | gauge | `vm_id` |
+| `vm_autoscale_vm_errors_total` | counter | `vm_id` |
+| `vm_autoscale_metric_unavailable_total` | counter | `vm_id`, `resource` |
+| `vm_autoscale_scaling_actions_total` | counter | `vm_id`, `resource`, `direction` |
+| `vm_autoscale_scaling_failures_total` | counter | `vm_id`, `resource` |
+| `vm_autoscale_host_cpu_percent` | gauge | `host` |
+| `vm_autoscale_host_ram_percent` | gauge | `host` |
+| `vm_autoscale_host_gate_blocked_total` | counter | `host` |
+
+::: tip Absent is not zero
+`vm_autoscale_vm_cpu_percent` is **removed** for a VM whose CPU could not be
+read, rather than reported as `0`. Emitting a zero would put the same lie into
+your dashboards that it used to put into the scaling decision. Watch
+`vm_autoscale_metric_unavailable_total` for that case.
+:::
+
+Alerts worth having:
+
+```yaml
+# The loop has stopped making progress
+- alert: VMAutoscaleStalled
+  expr: time() - vm_autoscale_last_cycle_timestamp_seconds > 900
+  for: 5m
+
+# A VM's metrics cannot be read, so it is no longer scaling
+- alert: VMAutoscaleMetricUnavailable
+  expr: increase(vm_autoscale_metric_unavailable_total[15m]) > 0
+
+# Scaling is being attempted and failing
+- alert: VMAutoscaleScalingFailures
+  expr: increase(vm_autoscale_scaling_failures_total[15m]) > 0
+
+# Flapping: up and down on the same VM within the hour
+- alert: VMAutoscaleFlapping
+  expr: |
+    increase(vm_autoscale_scaling_actions_total{direction="up"}[1h]) > 2
+    and
+    increase(vm_autoscale_scaling_actions_total{direction="down"}[1h]) > 2
+```
+
+## Monitoring without the endpoint
 
 **Is it alive?**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,5 +72,5 @@ journalctl -u vm_autoscale.service -f
 ```
 
 ::: warning Read this before running it in production
-The service authenticates to your Proxmox hosts as **root** and issues `qm set` against live guests. Read the [threat model](/security/) and the [known limitations](/reference/limitations) first. There is no dry-run mode.
+The service authenticates to your Proxmox hosts as **root** and issues `qm set` against live guests. Read the [threat model](/security/) and the [known limitations](/reference/limitations) first — and start with `dry_run: true`, which evaluates everything and changes nothing.
 :::

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -11,7 +11,9 @@ creates, clones, destroys or migrates a VM, does not handle LXC containers, and
 does not scale disk or network. Decisions come from a single instantaneous
 sample per polling cycle, compared against global thresholds; one step (1 core
 or 512 MB) per resource per cycle, bounded by configured limits and a
-per-resource cooldown. There is no dry-run mode.
+per-resource cooldown. `dry_run: true` evaluates everything and changes nothing.
+An optional Prometheus endpoint (off by default, localhost-bound) exports cycle,
+per-VM and per-node series.
 
 Key constraints a reader should know: the service authenticates to Proxmox
 nodes as root and holds those credentials in plain text in config.yaml. SSH

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -105,13 +105,22 @@ It is also a context manager, though `process_vm` uses explicit `connect()` / `c
 
 One method. Runs `pvesh get /nodes/$(hostname)/status --output-format json`, parses it, compares against the two ceilings, returns a boolean. Raises on JSON errors and missing fields — which surfaces as a per-VM `Error processing VM ...` rather than stopping the service.
 
+### `metrics.py`
+
+A small Prometheus registry and an HTTP endpoint served from a daemon thread,
+using only `http.server` — a client library is not worth a new dependency for
+one endpoint on a service whose install story is three apt packages. Disabled
+by default and localhost-bound when enabled. A metric that could not be read
+has its series **removed** rather than set to zero.
+
 ### `billing_tracker.py`
 
 Three dataclasses and a tracker. State is a single JSON file rewritten in full on every record. The main loop asks it once per cycle whether a billing period has elapsed and, when one has, generates a costed CSV per VM and fires any configured webhook.
 
 ## Threading and concurrency
 
-Effectively single-threaded. `threading.Lock` in `VMResourceManager` guards the cooldown timestamps, but nothing spawns a thread: hosts and VMs are processed sequentially, and each SSH command blocks.
+Effectively single-threaded, apart from the optional metrics endpoint, which
+serves from its own daemon thread against a lock-guarded registry. `threading.Lock` in `VMResourceManager` guards the cooldown timestamps, but nothing spawns a thread: hosts and VMs are processed sequentially, and each SSH command blocks.
 
 Consequences:
 
@@ -156,7 +165,7 @@ Realistic places to add behaviour without restructuring:
 
 ## Tests
 
-`tests/` holds 170 unit tests across eight files, run with `pytest`. SSH is mocked throughout, so there is no integration test against a real Proxmox node — but metrics now come from `pvesh --output-format json`, and the tests exercise that parsing against realistic payloads rather than a scraped table.
+`tests/` holds 201 unit tests across nine files, run with `pytest`. SSH is mocked throughout, so there is no integration test against a real Proxmox node — but metrics now come from `pvesh --output-format json`, and the tests exercise that parsing against realistic payloads rather than a scraped table.
 
 ```bash
 python3 -m pytest tests/ -q

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,7 +75,19 @@ scaling_limits:
 | `min_ram_mb` | int | `512` | Keep at `1024` or above — NUMA misbehaves below 1 GB |
 | `max_ram_mb` | int | `16384` | |
 
-Limits apply to **every** VM. Per-VM limits are not supported; run separate instances if you need them.
+These are the defaults for every VM. A VM may override any of them in its own
+entry, so a 2-core web server and a 16-core database can share one instance:
+
+```yaml
+virtual_machines:
+  - vm_id: 102
+    scaling_limits:
+      max_cores: 16
+      max_ram_mb: 32768
+```
+
+Resolution order: the VM's own block, then this section, then a flat top-level
+key (older layout), then the built-in default.
 
 ::: warning Behaviour change
 Older versions read these values under names that do not exist in this file, so the defaults above were enforced regardless of what you configured. If you are upgrading, your limits are about to take effect for the first time. Flat top-level `min_cores` / `max_cores` / `min_ram` / `max_ram` keys are still accepted as a fallback for legacy configs.
@@ -141,6 +153,47 @@ virtual_machines:
 | `cpu_scaling` | bool | no | Defaults to `false` |
 | `ram_scaling` | bool | no | Defaults to `false` |
 | `thresholds` | map | no | Per-VM overrides of `scaling_thresholds`. Flat (`cpu_high`, `cpu_low`, `ram_high`, `ram_low`) or nested (`cpu: { high, low }`). Any bound you omit keeps the global value |
+| `scaling_limits` | map | no | Per-VM overrides of the global `scaling_limits`. Same keys; any you omit keep the global value |
+
+## `dry_run`
+
+```yaml
+dry_run: false
+```
+
+| Type | Default | Notes |
+|---|---|---|
+| bool | `false` | Evaluate everything, change nothing |
+
+No command that touches a VM is issued — hotplug auto-configuration included.
+Reads still happen, so the evaluation is real; the cooldown still applies, so
+the cadence in the log is the cadence you would get. Notifications are prefixed
+`[DRY RUN]` and billing records nothing. See [operations](/guide/operations#dry-run).
+
+## `metrics`
+
+```yaml
+metrics:
+  enabled: false
+  bind: 127.0.0.1
+  port: 9808
+  path: /metrics
+```
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `false` | |
+| `bind` | string | `127.0.0.1` | |
+| `port` | int | `9808` | |
+| `path` | string | `/metrics` | |
+
+::: danger No authentication
+The endpoint has none, and the series name your nodes and VMIDs. Keep it on
+localhost unless something in front of it authenticates. A bind failure is
+logged and the service continues without metrics.
+:::
+
+Full metric list: [operations](/guide/operations#metrics).
 
 ## SSH host key verification
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -19,18 +19,6 @@ VMs are matched to hosts by exact string equality on `name`. A mismatch means th
 
 **Workaround:** after any config change, confirm every managed VM appears in a `VM <id> current usage` line within one cycle.
 
-### Command failures are reported as successes
-
-`execute_command` returns output and exit status without raising on a non-zero status, and the callers that issue `qm set` discard the result. So:
-
-```
-[INFO] RAM balloon set to 4096 MB for VM 101 (hotplug applied).
-```
-
-is logged whether or not `qm set` succeeded, and whether or not the guest honoured it.
-
-**Workaround:** verify with `qm config <vmid>` when a change matters.
-
 ## Documented-but-absent behaviour
 
 ### `logging` in `config.yaml` is inert by default
@@ -56,10 +44,6 @@ A node above `max_host_cpu_percent` or `max_host_ram_percent` has *all* scaling 
 ### Step sizes are not configurable
 
 Fixed at 1 core and 512 MB per action, in `vm_manager.py`. Recovering from a large jump takes many cycles.
-
-### Limits are global
-
-`scaling_limits` applies to every VM. A 2-core web server and a 16-core database cannot have different ceilings in one instance.
 
 ### Single instance, no HA
 
@@ -107,13 +91,11 @@ The shipped unit sets `User=root` with no systemd sandboxing directives.
 
 `v1.2.0` was published in December 2025 and `v0.1.1` in April 2026 — the two release lines were never reconciled. `v1.2.0` is now [documented retroactively](/reference/changelog) and numbering is monotonic from `v1.3.0` onwards, but the historical tags stay as they are.
 
-### No dry-run mode
+### A guest can still refuse a change the hypervisor accepted
 
-There is no way to see what the service *would* do. The closest approximation is `scaling_enabled: false` everywhere, which produces the monitoring output without acting.
+`qm set` failures are now detected, but QEMU accepting a command is not the same as the guest honouring it. A missing balloon driver, or a kernel that refuses a CPU hot-unplug, produces a successful command and no change inside the guest.
 
-### No metrics endpoint
-
-No Prometheus exporter, no health endpoint, no structured events. Monitoring means parsing the log — see [operations](/guide/operations#monitoring-the-autoscaler-itself).
+**Workaround:** verify from inside the guest — `nproc`, `free -m` — when a change matters.
 
 ---
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -56,7 +56,7 @@ Raised for missing sections and incomplete channel configuration.
 ### `class VMResourceManager`
 
 ```python
-VMResourceManager(ssh_client, vm_id, config: dict)
+VMResourceManager(ssh_client, vm_id, config: dict, vm_config: dict | None = None)
 ```
 
 Runs hotplug auto-configuration in the constructor when `auto_configure_hotplug` is true.
@@ -75,8 +75,10 @@ Runs hotplug auto-configuration in the constructor when `auto_configure_hotplug`
 
 | Method | Purpose |
 |---|---|
+| `_run(command, check=True, mutating=False)` | Runs a command; raises `CommandFailed` on a non-zero exit, and refuses mutating commands under `dry_run` |
+| `_unpack(result)` | Normalises an SSH result into `(stdout, stderr, exit_status)` |
 | `_mark_scaled(resource)` | Starts the cooldown for that resource |
-| `_scaling_limit(key, legacy_key, default)` | `scaling_limits` → flat key → default |
+| `_scaling_limit(key, legacy_key, default)` | Per-VM `scaling_limits` → global `scaling_limits` → flat key → default |
 | `_get_min_cores` / `_get_max_cores` | Resolved limits |
 | `_get_min_ram` / `_get_max_ram` | Resolved limits, MB |
 | `_get_current_cores` / `_get_current_vcpus` / `_get_current_ram` | Parsed from `qm config` |
@@ -122,6 +124,34 @@ HostResourceChecker(ssh_client)
 | `check_host_resources` | `(max_cpu_pct, max_ram_pct) -> bool` | `True` when both are within limits. Raises on JSON or field errors |
 
 RAM is `memory.used / memory.total`, matching the Proxmox web UI.
+
+## `metrics.py`
+
+Prometheus text exposition over `http.server`, in a daemon thread. No third-party
+dependency.
+
+### `class MetricsRegistry`
+
+| Method | Signature | Notes |
+|---|---|---|
+| `describe` | `(name, kind, help_text) -> None` | Registers `# HELP` / `# TYPE` |
+| `inc` | `(name, labels=None, amount=1.0) -> None` | Counter |
+| `set` | `(name, value, labels=None) -> None` | Gauge |
+| `unset` | `(name, labels=None) -> None` | Drops a series — used when a metric is unreadable |
+| `render` | `() -> str` | Exposition format |
+
+### `class MetricsServer`
+
+```python
+MetricsServer(registry, logger, bind="127.0.0.1", port=9808, path="/metrics")
+```
+
+`start()` returns `False` rather than raising when the port cannot be bound; a
+metrics endpoint is not worth taking the autoscaler down for. `stop()` shuts the
+thread down.
+
+`build_registry()` returns a registry with every metric this service reports
+already described.
 
 ## `billing_tracker.py`
 

--- a/host_resource_checker.py
+++ b/host_resource_checker.py
@@ -13,6 +13,10 @@ class HostResourceChecker:
         """
         self.ssh_client = ssh_client
         self.logger = logging.getLogger("host_resource_checker")
+        # Last computed percentages, so callers can report them without
+        # running the query a second time.
+        self.last_cpu_percent = None
+        self.last_ram_percent = None
 
     def check_host_resources(self, max_host_cpu_percent, max_host_ram_percent):
         """
@@ -56,6 +60,9 @@ class HostResourceChecker:
 
             # Calculate RAM usage based on 'used' (excludes buff/cache, matches Proxmox WebUI)
             host_ram_usage = (used_mem / total_mem) * 100
+
+            self.last_cpu_percent = host_cpu_usage
+            self.last_ram_percent = host_ram_usage
             
             # Log resource usage
             self.logger.info(f"Host CPU Usage: {host_cpu_usage:.2f}%, "

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,238 @@
+"""
+Prometheus metrics for VM Autoscale.
+
+A tiny text-exposition endpoint served from a daemon thread. No dependencies
+beyond the standard library, because adding a client library to a service whose
+whole install story is three apt packages is not worth one endpoint.
+
+The server is **disabled by default and binds to localhost when enabled**. This
+process holds root credentials for hypervisors; the metrics it exposes name
+your nodes, your VMIDs and their utilisation, and there is no authentication.
+Put it behind something that authenticates if it needs to leave the host.
+"""
+
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional, Tuple
+
+CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+DEFAULT_BIND = "127.0.0.1"
+DEFAULT_PORT = 9808
+DEFAULT_PATH = "/metrics"
+
+
+def _escape_label(value: Any) -> str:
+    """Escape a label value per the Prometheus exposition format."""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+    )
+
+
+def _format_labels(labels: Tuple[Tuple[str, str], ...]) -> str:
+    if not labels:
+        return ""
+    inner = ",".join(f'{name}="{_escape_label(value)}"' for name, value in labels)
+    return "{" + inner + "}"
+
+
+class MetricsRegistry:
+    """Thread-safe store for the handful of metrics this service reports.
+
+    Counters only ever increase; gauges are overwritten. Both are keyed by
+    their label set, and a metric with no observations is simply not emitted -
+    Prometheus treats an absent series and a zero series differently, and
+    inventing zeros for VMs that were never polled would be a lie.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counters: Dict[Tuple[str, Tuple[Tuple[str, str], ...]], float] = {}
+        self._gauges: Dict[Tuple[str, Tuple[Tuple[str, str], ...]], float] = {}
+        self._help: Dict[str, Tuple[str, str]] = {}
+
+    def describe(self, name: str, kind: str, help_text: str) -> None:
+        with self._lock:
+            self._help[name] = (kind, help_text)
+
+    @staticmethod
+    def _key(name: str, labels: Optional[Dict[str, Any]]):
+        items = tuple(sorted((k, str(v)) for k, v in (labels or {}).items()))
+        return name, items
+
+    def inc(self, name: str, labels: Optional[Dict[str, Any]] = None,
+            amount: float = 1.0) -> None:
+        key = self._key(name, labels)
+        with self._lock:
+            self._counters[key] = self._counters.get(key, 0.0) + amount
+
+    def set(self, name: str, value: float,
+            labels: Optional[Dict[str, Any]] = None) -> None:
+        key = self._key(name, labels)
+        with self._lock:
+            self._gauges[key] = float(value)
+
+    def unset(self, name: str, labels: Optional[Dict[str, Any]] = None) -> None:
+        """Drop a gauge series, for a VM that no longer reports a value."""
+        key = self._key(name, labels)
+        with self._lock:
+            self._gauges.pop(key, None)
+
+    def render(self) -> str:
+        """Render the whole registry in Prometheus text exposition format."""
+        with self._lock:
+            counters = dict(self._counters)
+            gauges = dict(self._gauges)
+            help_text = dict(self._help)
+
+        by_name: Dict[str, list] = {}
+        for (name, labels), value in counters.items():
+            by_name.setdefault(name, []).append((labels, value))
+        for (name, labels), value in gauges.items():
+            by_name.setdefault(name, []).append((labels, value))
+
+        lines = []
+        for name in sorted(by_name):
+            kind, text = help_text.get(name, ("untyped", ""))
+            if text:
+                lines.append(f"# HELP {name} {text}")
+            lines.append(f"# TYPE {name} {kind}")
+            for labels, value in sorted(by_name[name]):
+                rendered = f"{value:.6g}" if value % 1 else f"{int(value)}"
+                lines.append(f"{name}{_format_labels(labels)} {rendered}")
+        return "\n".join(lines) + "\n"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    registry: MetricsRegistry
+    metrics_path: str = DEFAULT_PATH
+    logger: logging.Logger
+
+    def do_GET(self):  # noqa: N802 - name fixed by BaseHTTPRequestHandler
+        if self.path.split("?", 1)[0] != self.metrics_path:
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"not found\n")
+            return
+
+        try:
+            body = self.registry.render().encode("utf-8")
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error(f"Failed to render metrics: {e}")
+            self.send_response(500)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", CONTENT_TYPE)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        # BaseHTTPRequestHandler logs every request to stderr by default, which
+        # would drown the service log under a normal scrape interval.
+        self.logger.debug("metrics: " + fmt % args)
+
+
+class MetricsServer:
+    """Serves a registry over HTTP from a daemon thread."""
+
+    def __init__(self, registry: MetricsRegistry, logger: logging.Logger,
+                 bind: str = DEFAULT_BIND, port: int = DEFAULT_PORT,
+                 path: str = DEFAULT_PATH) -> None:
+        self.registry = registry
+        self.logger = logger
+        self.bind = bind
+        self.port = port
+        self.path = path if path.startswith("/") else "/" + path
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> bool:
+        """Start serving. Returns False if the endpoint could not be bound.
+
+        A metrics endpoint is not worth taking the autoscaler down for, so a
+        bind failure is logged and the service carries on without it.
+        """
+        handler = type("_BoundHandler", (_Handler,), {
+            "registry": self.registry,
+            "metrics_path": self.path,
+            "logger": self.logger,
+        })
+
+        try:
+            self._server = ThreadingHTTPServer((self.bind, self.port), handler)
+        except OSError as e:
+            self.logger.error(
+                f"Could not bind the metrics endpoint to {self.bind}:{self.port}: {e}. "
+                "Continuing without metrics."
+            )
+            return False
+
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="vm-autoscale-metrics",
+            daemon=True,
+        )
+        self._thread.start()
+        self.logger.info(
+            f"Metrics available on http://{self.bind}:{self.port}{self.path}"
+        )
+        return True
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+
+def build_registry() -> MetricsRegistry:
+    """A registry with every metric this service reports already described."""
+    r = MetricsRegistry()
+
+    r.describe("vm_autoscale_up", "gauge",
+               "1 when the autoscaler is running.")
+    r.describe("vm_autoscale_build_info", "gauge",
+               "Build information; the value is always 1.")
+    r.describe("vm_autoscale_cycles_total", "counter",
+               "Polling cycles completed since start.")
+    r.describe("vm_autoscale_cycle_duration_seconds", "gauge",
+               "Wall-clock duration of the last completed cycle.")
+    r.describe("vm_autoscale_last_cycle_timestamp_seconds", "gauge",
+               "Unix time at which the last cycle completed.")
+    r.describe("vm_autoscale_cycle_errors_total", "counter",
+               "Unexpected errors raised by the main loop.")
+
+    r.describe("vm_autoscale_vm_running", "gauge",
+               "1 when the guest was running at the last poll.")
+    r.describe("vm_autoscale_vm_cpu_percent", "gauge",
+               "Guest CPU usage at the last poll. Absent when unreadable.")
+    r.describe("vm_autoscale_vm_ram_percent", "gauge",
+               "Guest RAM usage at the last poll. Absent when unreadable.")
+    r.describe("vm_autoscale_vm_errors_total", "counter",
+               "Failures while processing a VM.")
+    r.describe("vm_autoscale_metric_unavailable_total", "counter",
+               "Times a usage metric could not be read, by resource.")
+
+    r.describe("vm_autoscale_scaling_actions_total", "counter",
+               "Scaling actions applied, by VM, resource and direction.")
+    r.describe("vm_autoscale_scaling_failures_total", "counter",
+               "Scaling attempts that raised, by VM and resource.")
+
+    r.describe("vm_autoscale_host_cpu_percent", "gauge",
+               "Proxmox node CPU usage at the last check.")
+    r.describe("vm_autoscale_host_ram_percent", "gauge",
+               "Proxmox node RAM usage at the last check.")
+    r.describe("vm_autoscale_host_gate_blocked_total", "counter",
+               "Times a node was over its ceiling and scaling was skipped.")
+
+    r.set("vm_autoscale_up", 1)
+    return r

--- a/tests/test_autoscale.py
+++ b/tests/test_autoscale.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch, call
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from metrics import build_registry
 from autoscale import NotificationManager, ConfigurationError, VMAutoscaler
 
 
@@ -212,6 +213,8 @@ class TestHandleCPUScaling(unittest.TestCase):
         a.logger = make_logger()
         a.notification_manager = MagicMock()
         a.billing_tracker = None
+        a.dry_run = False
+        a.metrics = build_registry()
         return a
 
     def test_scales_up_on_high_cpu(self):
@@ -269,6 +272,8 @@ class TestHandleRAMScaling(unittest.TestCase):
         a.logger = make_logger()
         a.notification_manager = MagicMock()
         a.billing_tracker = None
+        a.dry_run = False
+        a.metrics = build_registry()
         return a
 
     def test_scales_up_on_high_ram(self):
@@ -504,6 +509,8 @@ class TestUnreadableMetricsNeverScale(unittest.TestCase):
         a.logger = make_logger()
         a.notification_manager = MagicMock()
         a.billing_tracker = None
+        a.dry_run = False
+        a.metrics = build_registry()
         a._vm_managers = {}
         return a
 

--- a/tests/test_dryrun_metrics_limits.py
+++ b/tests/test_dryrun_metrics_limits.py
@@ -1,0 +1,298 @@
+"""
+Regression tests for four defects fixed together.
+
+1. `qm set` failures were reported as successes: `execute_command` returns the
+   exit status instead of raising, and every caller discarded it.
+2. There was no dry-run mode, so there was no way to see what the service would
+   do without letting it do it.
+3. `scaling_limits` was global, so one instance could not manage a 2-core web
+   server and a 16-core database.
+4. There was no way to monitor the service except by parsing its log.
+"""
+
+import json
+import logging
+import os
+import sys
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from metrics import MetricsRegistry, MetricsServer, build_registry
+from vm_manager import CommandFailed, VMResourceManager
+
+
+def make_logger():
+    logger = logging.getLogger("test")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+
+def ssh_returning(config_text="cores: 4\nvcpus: 4\nmemory: 4096\nhotplug: cpu,memory\nnuma: 1",
+                  status=0, running=True, set_status=0):
+    """SSH double with independently controllable read and write statuses."""
+    ssh = MagicMock()
+
+    def respond(cmd, *args, **kwargs):
+        if "qm status" in cmd:
+            return ("status: running" if running else "status: stopped", "", 0)
+        if "qm set" in cmd:
+            return ("", "unable to modify" if set_status else "", set_status)
+        return (config_text, "permission denied" if status else "", status)
+
+    ssh.execute_command.side_effect = respond
+    return ssh
+
+
+def manager(ssh, config=None, vm_config=None):
+    cfg = {"auto_configure_hotplug": False, "scale_cooldown": 0,
+           "scaling_limits": {"min_cores": 1, "max_cores": 8,
+                              "min_ram_mb": 512, "max_ram_mb": 16384}}
+    cfg.update(config or {})
+    return VMResourceManager(ssh, "101", cfg, vm_config)
+
+
+# ---------------------------------------------------------------------------
+# 1. Command failures
+# ---------------------------------------------------------------------------
+
+class TestCommandFailuresAreNotSuccesses(unittest.TestCase):
+
+    def test_a_failing_qm_set_raises(self):
+        mgr = manager(ssh_returning(set_status=2))
+        with self.assertRaises(CommandFailed):
+            mgr._set_ram(2048)
+
+    def test_the_error_names_the_command_and_the_status(self):
+        mgr = manager(ssh_returning(set_status=2))
+        with self.assertRaises(CommandFailed) as ctx:
+            mgr._set_cores(4)
+        message = str(ctx.exception)
+        self.assertIn("qm set 101 -cores 4", message)
+        self.assertIn("2", message)
+        self.assertIn("unable to modify", message)
+
+    def test_a_failed_scale_does_not_start_the_cooldown(self):
+        """A command that did not work must not rate-limit the next attempt."""
+        mgr = manager(ssh_returning(set_status=1), {"scale_cooldown": 300})
+        with self.assertRaises(CommandFailed):
+            mgr.scale_cpu("up")
+        self.assertTrue(mgr.can_scale("cpu"))
+
+    def test_a_failing_read_raises_instead_of_inventing_a_value(self):
+        """Returning a default of 1 core made scale_cpu act on a fiction."""
+        mgr = manager(ssh_returning(status=1))
+        with self.assertRaises(CommandFailed):
+            mgr._get_current_cores()
+
+    def test_an_absent_key_still_means_the_proxmox_default(self):
+        mgr = manager(ssh_returning(config_text="name: web1"))
+        self.assertEqual(mgr._get_current_cores(), 1)
+        self.assertEqual(mgr._get_current_ram(), 512)
+
+    def test_a_missing_vm_is_not_retried(self):
+        ssh = MagicMock()
+        ssh.execute_command.return_value = ("", "no such VM", 2)
+        mgr = manager(ssh)
+        with patch("time.sleep") as slept:
+            self.assertFalse(mgr.is_vm_running())
+        slept.assert_not_called()
+
+    def test_bare_string_results_are_still_accepted(self):
+        """Older doubles and call paths hand back a plain string."""
+        self.assertEqual(VMResourceManager._unpack("cores: 2"), ("cores: 2", "", 0))
+        self.assertEqual(VMResourceManager._unpack(("out", "err", 3)), ("out", "err", 3))
+
+
+# ---------------------------------------------------------------------------
+# 2. Dry run
+# ---------------------------------------------------------------------------
+
+class TestDryRun(unittest.TestCase):
+
+    def _issued(self, ssh):
+        return [c.args[0] for c in ssh.execute_command.call_args_list]
+
+    def test_no_qm_set_is_issued(self):
+        ssh = ssh_returning()
+        mgr = manager(ssh, {"dry_run": True})
+        mgr.scale_cpu("up")
+        self.assertFalse([c for c in self._issued(ssh) if "qm set" in c])
+
+    def test_reads_still_happen(self):
+        """Dry run must still evaluate, or it would show nothing useful."""
+        ssh = ssh_returning()
+        mgr = manager(ssh, {"dry_run": True})
+        mgr.scale_cpu("up")
+        self.assertTrue([c for c in self._issued(ssh) if "qm config" in c])
+
+    def test_the_decision_is_still_reported_as_taken(self):
+        ssh = ssh_returning()
+        mgr = manager(ssh, {"dry_run": True})
+        self.assertTrue(mgr.scale_cpu("up"))
+
+    def test_hotplug_autoconfiguration_changes_nothing(self):
+        ssh = ssh_returning(config_text="cores: 4\nmemory: 8192")
+        manager(ssh, {"dry_run": True, "auto_configure_hotplug": True})
+        self.assertFalse([c for c in self._issued(ssh) if "qm set" in c])
+
+    def test_ram_scaling_issues_nothing_either(self):
+        ssh = ssh_returning()
+        mgr = manager(ssh, {"dry_run": True})
+        mgr.scale_ram("up")
+        self.assertFalse([c for c in self._issued(ssh) if "qm set" in c])
+
+    def test_it_is_off_by_default(self):
+        self.assertFalse(manager(ssh_returning()).dry_run)
+
+    def test_a_real_run_does_issue_the_command(self):
+        ssh = ssh_returning()
+        mgr = manager(ssh)
+        mgr.scale_cpu("up")
+        self.assertTrue([c for c in self._issued(ssh) if "qm set" in c])
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-VM scaling limits
+# ---------------------------------------------------------------------------
+
+class TestPerVMScalingLimits(unittest.TestCase):
+
+    def test_a_vm_can_raise_its_own_ceiling(self):
+        mgr = manager(ssh_returning(), vm_config={"scaling_limits": {"max_cores": 16}})
+        self.assertEqual(mgr._get_max_cores(), 16)
+
+    def test_unset_bounds_fall_back_to_the_global_section(self):
+        mgr = manager(ssh_returning(), vm_config={"scaling_limits": {"max_cores": 16}})
+        self.assertEqual(mgr._get_min_cores(), 1)
+        self.assertEqual(mgr._get_max_ram(), 16384)
+
+    def test_no_per_vm_block_means_the_global_values(self):
+        mgr = manager(ssh_returning(), vm_config={})
+        self.assertEqual(mgr._get_max_cores(), 8)
+
+    def test_a_lower_per_vm_ceiling_blocks_scaling_the_global_one_would_allow(self):
+        mgr = manager(ssh_returning(config_text="cores: 4\nvcpus: 4"),
+                      vm_config={"scaling_limits": {"max_cores": 4}})
+        self.assertFalse(mgr.scale_cpu("up"))
+
+    def test_a_higher_per_vm_ceiling_allows_scaling_the_global_one_would_block(self):
+        mgr = manager(ssh_returning(config_text="cores: 8\nvcpus: 8\nhotplug: cpu\nnuma: 1"),
+                      vm_config={"scaling_limits": {"max_cores": 16}})
+        self.assertTrue(mgr.scale_cpu("up"))
+
+    def test_a_non_mapping_block_is_ignored(self):
+        mgr = manager(ssh_returning(), vm_config={"scaling_limits": "nonsense"})
+        self.assertEqual(mgr._get_max_cores(), 8)
+
+
+# ---------------------------------------------------------------------------
+# 4. Metrics
+# ---------------------------------------------------------------------------
+
+class TestMetricsRegistry(unittest.TestCase):
+
+    def test_counters_accumulate_per_label_set(self):
+        r = MetricsRegistry()
+        r.describe("actions_total", "counter", "Actions.")
+        r.inc("actions_total", {"vm_id": "101"})
+        r.inc("actions_total", {"vm_id": "101"})
+        r.inc("actions_total", {"vm_id": "102"})
+        out = r.render()
+        self.assertIn('actions_total{vm_id="101"} 2', out)
+        self.assertIn('actions_total{vm_id="102"} 1', out)
+
+    def test_gauges_are_overwritten(self):
+        r = MetricsRegistry()
+        r.describe("cpu", "gauge", "CPU.")
+        r.set("cpu", 10, {"vm_id": "101"})
+        r.set("cpu", 42.5, {"vm_id": "101"})
+        self.assertIn('cpu{vm_id="101"} 42.5', r.render())
+
+    def test_unset_removes_the_series_entirely(self):
+        """An unreadable metric must be absent, not zero."""
+        r = MetricsRegistry()
+        r.describe("cpu", "gauge", "CPU.")
+        r.set("cpu", 42, {"vm_id": "101"})
+        r.unset("cpu", {"vm_id": "101"})
+        self.assertNotIn("cpu{", r.render())
+
+    def test_help_and_type_lines_are_emitted(self):
+        r = MetricsRegistry()
+        r.describe("cycles_total", "counter", "Cycles completed.")
+        r.inc("cycles_total")
+        out = r.render()
+        self.assertIn("# HELP cycles_total Cycles completed.", out)
+        self.assertIn("# TYPE cycles_total counter", out)
+
+    def test_label_values_are_escaped(self):
+        r = MetricsRegistry()
+        r.describe("g", "gauge", "G.")
+        r.set("g", 1, {"host": 'we"ird\\path'})
+        self.assertIn(r'host="we\"ird\\path"', r.render())
+
+    def test_concurrent_increments_are_not_lost(self):
+        r = MetricsRegistry()
+        r.describe("c", "counter", "C.")
+
+        def bump():
+            for _ in range(500):
+                r.inc("c")
+
+        threads = [threading.Thread(target=bump) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertIn("c 2000", r.render())
+
+    def test_the_shipped_registry_describes_what_it_exports(self):
+        r = build_registry()
+        out = r.render()
+        self.assertIn("vm_autoscale_up 1", out)
+        self.assertIn("# TYPE vm_autoscale_up gauge", out)
+
+
+class TestMetricsServer(unittest.TestCase):
+
+    def setUp(self):
+        self.registry = build_registry()
+        self.registry.inc("vm_autoscale_cycles_total")
+        self.server = MetricsServer(self.registry, make_logger(),
+                                    bind="127.0.0.1", port=0, path="/metrics")
+        self.assertTrue(self.server.start())
+        self.addCleanup(self.server.stop)
+        self.port = self.server._server.server_address[1]
+
+    def url(self, path):
+        return f"http://127.0.0.1:{self.port}{path}"
+
+    def test_serves_the_exposition_format(self):
+        with urllib.request.urlopen(self.url("/metrics"), timeout=5) as resp:
+            body = resp.read().decode()
+            self.assertEqual(resp.status, 200)
+            self.assertIn("version=0.0.4", resp.headers["Content-Type"])
+        self.assertIn("vm_autoscale_cycles_total 1", body)
+
+    def test_other_paths_are_404(self):
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            urllib.request.urlopen(self.url("/"), timeout=5)
+        self.assertEqual(ctx.exception.code, 404)
+
+    def test_a_query_string_still_matches(self):
+        with urllib.request.urlopen(self.url("/metrics?x=1"), timeout=5) as resp:
+            self.assertEqual(resp.status, 200)
+
+    def test_a_bind_failure_is_survivable(self):
+        """A metrics endpoint is not worth taking the autoscaler down for."""
+        clash = MetricsServer(build_registry(), make_logger(),
+                              bind="127.0.0.1", port=self.port)
+        self.assertFalse(clash.start())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_thresholds_hostkeys_billing.py
+++ b/tests/test_thresholds_hostkeys_billing.py
@@ -23,6 +23,7 @@ import paramiko
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from metrics import build_registry
 from autoscale import VMAutoscaler
 from billing_tracker import BillingTracker, SpecChangeRecord, StateChangeRecord
 from ssh_utils import SSHClient
@@ -43,6 +44,8 @@ def bare_autoscaler(config):
     a.billing_tracker = None
     a._vm_managers = {}
     a._vm_states = {}
+    a.dry_run = False
+    a.metrics = build_registry()
     return a
 
 

--- a/vm_manager.py
+++ b/vm_manager.py
@@ -5,11 +5,18 @@ import time
 import threading
 
 
+class CommandFailed(RuntimeError):
+    """A command returned a non-zero exit status on the Proxmox node."""
+
+
 class VMResourceManager:
-    def __init__(self, ssh_client, vm_id, config):
+    def __init__(self, ssh_client, vm_id, config, vm_config=None):
         self.ssh_client = ssh_client
         self.vm_id = vm_id
         self.config = config
+        # The VM's own entry from `virtual_machines`, when the caller has it.
+        # Used for per-VM `scaling_limits` overrides.
+        self.vm_config = vm_config or {}
         self.logger = logging.getLogger("vm_resource_manager")
         # CPU and RAM are rate-limited independently: a CPU change must not
         # swallow the RAM cooldown (and vice versa) within the same cycle.
@@ -19,6 +26,9 @@ class VMResourceManager:
         self.scale_lock = threading.Lock()  # Added lock for scaling control
         self.auto_configure_hotplug = self.config.get("auto_configure_hotplug", True)
         self._hotplug_configured = False
+        # When set, no command that changes the hypervisor is issued; the
+        # service logs what it would have done instead.
+        self.dry_run = bool(self.config.get("dry_run", False))
 
         self.ensure_hotplug_configured()
 
@@ -54,9 +64,7 @@ class VMResourceManager:
                 self.logger.info(f"VM {self.vm_id}: Enabling NUMA for memory hotplug support")
             
             if needs_update:
-                command = f"qm set {self.vm_id} {' '.join(updates)}"
-                output = self.ssh_client.execute_command(command)
-                self._get_command_output(output)
+                self._run(f"qm set {self.vm_id} {' '.join(updates)}", mutating=True)
                 self.logger.info(
                     f"VM {self.vm_id}: Hotplug configuration updated. "
                     "Note: NUMA changes require a VM restart to take effect."
@@ -77,16 +85,65 @@ class VMResourceManager:
             return str(output[0]).strip() if output and output[0] is not None else ""
         return str(output).strip() if output is not None else ""
 
+    @staticmethod
+    def _unpack(result):
+        """Normalise an SSH result into (stdout, stderr, exit_status).
+
+        `execute_command` returns a 3-tuple, but doubles in the test suite and
+        older call paths hand back a bare string; treat that as a success.
+        """
+        if isinstance(result, tuple):
+            out = result[0] if len(result) > 0 and result[0] is not None else ""
+            err = result[1] if len(result) > 1 and result[1] is not None else ""
+            status = result[2] if len(result) > 2 and result[2] is not None else 0
+            return str(out).strip(), str(err).strip(), int(status)
+        return (str(result).strip() if result is not None else ""), "", 0
+
+    def _run(self, command, check=True, mutating=False):
+        """Run a command on the node and return its stdout.
+
+        `check` makes a non-zero exit status raise. Without it, `qm set`
+        failures were invisible: `execute_command` returns the status rather
+        than raising, and every caller discarded it, so the service logged
+        "RAM set to 4096 MB" whether or not the command had worked.
+
+        `mutating` marks a command that changes the hypervisor. Those are the
+        ones dry-run refuses to execute.
+        """
+        if mutating and self.dry_run:
+            self.logger.info(f"[dry-run] VM {self.vm_id}: would run `{command}`")
+            return ""
+
+        result = self.ssh_client.execute_command(command)
+        output, error, status = self._unpack(result)
+
+        if check and status != 0:
+            detail = f": {error}" if error else ""
+            raise CommandFailed(
+                f"`{command}` failed on VM {self.vm_id} with exit status {status}{detail}"
+            )
+        return output
+
     def is_vm_running(self, retries=3, delay=5):
         """Check if the VM is running with retries and improved error handling."""
         for attempt in range(1, retries + 1):
             try:
                 command = f"qm status {self.vm_id} --verbose"
                 self.logger.debug(f"Executing command to check VM status: {command}")
-                output = self.ssh_client.execute_command(command)
-                output_str = self._get_command_output(output)
+                output_str, error, status = self._unpack(
+                    self.ssh_client.execute_command(command)
+                )
                 self.logger.debug(f"Command output: {output_str}")
-        
+
+                if status != 0:
+                    # A VM that does not exist is not a transient fault; retrying
+                    # three times with backoff would just cost 30 seconds.
+                    self.logger.error(
+                        f"`{command}` failed with exit status {status}"
+                        f"{': ' + error if error else ''}"
+                    )
+                    return False
+
                 if "status: running" in output_str.lower():
                     self.logger.info(f"VM {self.vm_id} is running.")
                     return True
@@ -313,41 +370,47 @@ class VMResourceManager:
             raise
 
     def _get_current_vcpus(self):
-        """Retrieve current vCPUs assigned to the VM."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            match = re.search(r"vcpus:\s*(\d+)", output_str)
-            return int(match.group(1)) if match else 1
-        except Exception as e:
-            self.logger.error(f"Failed to retrieve vCPUs: {e}")
-            return 1
+        """Read this value from `qm config`.
+
+        Raises when the command itself fails, rather than substituting a
+        default: a fabricated value would be fed straight into a scaling
+        decision. `vcpus` is omitted from `qm config` when every core is online.
+        """
+        output = self._run(f"qm config {self.vm_id}")
+        match = re.search(r"vcpus:\s*(\d+)", output)
+        return int(match.group(1)) if match else 1
 
     def _get_current_cores(self):
-        """Retrieve current CPU cores assigned to the VM."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            match = re.search(r"cores:\s*(\d+)", output_str)
-            return int(match.group(1)) if match else 1
-        except Exception as e:
-            self.logger.error(f"Failed to retrieve CPU cores: {e}")
-            return 1
+        """Read this value from `qm config`.
+
+        Raises when the command itself fails, rather than substituting a
+        default: a fabricated value would be fed straight into a scaling
+        decision. `cores` is omitted from `qm config` at the Proxmox default of 1.
+        """
+        output = self._run(f"qm config {self.vm_id}")
+        match = re.search(r"cores:\s*(\d+)", output)
+        return int(match.group(1)) if match else 1
 
     def _scaling_limit(self, key, legacy_key, default):
-        """Read a limit from the `scaling_limits` section of the config.
+        """Resolve one scaling limit, most specific source first.
 
-        Falls back to a flat top-level key (older config layout) and finally to
-        `default`, so existing installations keep working after the move to
-        the documented `scaling_limits:` section.
+        Order: the VM's own `scaling_limits` block, then the global
+        `scaling_limits` section, then a flat top-level key (older config
+        layout), then `default`. Per-VM limits let a 2-core web server and a
+        16-core database share one instance, which global-only limits could
+        not express.
         """
+        per_vm = self.vm_config.get("scaling_limits") or {}
+        if isinstance(per_vm, dict) and per_vm.get(key) is not None:
+            return per_vm[key]
+
         limits = self.config.get("scaling_limits") or {}
         if key in limits and limits[key] is not None:
             return limits[key]
+
         if legacy_key in self.config and self.config[legacy_key] is not None:
             return self.config[legacy_key]
+
         return default
 
     def _get_max_cores(self):
@@ -359,16 +422,15 @@ class VMResourceManager:
         return self._scaling_limit("min_cores", "min_cores", 1)
 
     def _get_current_ram(self):
-        """Retrieve current RAM assigned to the VM."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            match = re.search(r"memory:\s*(\d+)", output_str)
-            return int(match.group(1)) if match else 512
-        except Exception as e:
-            self.logger.error(f"Failed to retrieve current RAM: {e}")
-            return 512
+        """Read this value from `qm config`.
+
+        Raises when the command itself fails, rather than substituting a
+        default: a fabricated value would be fed straight into a scaling
+        decision. `memory` is omitted from `qm config` at the Proxmox default of 512 MB.
+        """
+        output = self._run(f"qm config {self.vm_id}")
+        match = re.search(r"memory:\s*(\d+)", output)
+        return int(match.group(1)) if match else 512
 
     def _get_max_ram(self):
         """Retrieve maximum allowed RAM in MB."""
@@ -379,53 +441,30 @@ class VMResourceManager:
         return self._scaling_limit("min_ram_mb", "min_ram", 512)
 
     def _check_hotplug_enabled(self):
-        """Check if hotplug is enabled for CPU and memory on this VM."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            
-            # Check for hotplug setting (e.g., "hotplug: cpu,memory" or "hotplug: network,disk,cpu,memory")
-            hotplug_match = re.search(r"hotplug:\s*([^\n]+)", output_str)
-            if hotplug_match:
-                hotplug_settings = hotplug_match.group(1).lower()
-                cpu_hotplug = 'cpu' in hotplug_settings
-                memory_hotplug = 'memory' in hotplug_settings
-                return cpu_hotplug, memory_hotplug
-            
-            # If no hotplug line, hotplug is disabled
+        """Whether CPU and memory hotplug are enabled for this VM.
+
+        Raises when `qm config` fails. Reporting "no hotplug" on a failed read
+        would silently downgrade a live scale to a reboot-required one.
+        """
+        output = self._run(f"qm config {self.vm_id}")
+        hotplug_match = re.search(r"hotplug:\s*([^\n]+)", output)
+        if not hotplug_match:
+            # No hotplug line at all means hotplug is off.
             return False, False
-        except Exception as e:
-            self.logger.error(f"Failed to check hotplug settings: {e}")
-            return False, False
+        settings = hotplug_match.group(1).lower()
+        return 'cpu' in settings, 'memory' in settings
 
     def _check_numa_enabled(self):
-        """Check if NUMA is enabled on this VM (required for memory hotplug)."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            
-            # Check for numa setting
-            numa_match = re.search(r"numa:\s*(\d+)", output_str)
-            if numa_match:
-                return int(numa_match.group(1)) == 1
-            return False
-        except Exception as e:
-            self.logger.error(f"Failed to check NUMA settings: {e}")
-            return False
+        """Whether NUMA is enabled on this VM (required for memory hotplug)."""
+        output = self._run(f"qm config {self.vm_id}")
+        numa_match = re.search(r"numa:\s*(\d+)", output)
+        return bool(numa_match) and int(numa_match.group(1)) == 1
 
     def _get_balloon_value(self):
-        """Get current balloon memory value."""
-        try:
-            command = f"qm config {self.vm_id}"
-            output = self.ssh_client.execute_command(command)
-            output_str = self._get_command_output(output)
-            match = re.search(r"balloon:\s*(\d+)", output_str)
-            return int(match.group(1)) if match else None
-        except Exception as e:
-            self.logger.debug(f"Failed to get balloon value: {e}")
-            return None
+        """Current balloon target in MB, or None when the key is absent."""
+        output = self._run(f"qm config {self.vm_id}")
+        match = re.search(r"balloon:\s*(\d+)", output)
+        return int(match.group(1)) if match else None
 
     def _set_ram(self, ram):
         """Set the RAM for the VM, using balloon for hotplug if available."""
@@ -436,9 +475,7 @@ class VMResourceManager:
             
             if is_running and memory_hotplug and numa_enabled:
                 # Use balloon for immediate effect on running VMs with hotplug
-                command = f"qm set {self.vm_id} -balloon {ram}"
-                output = self.ssh_client.execute_command(command)
-                self._get_command_output(output)
+                self._run(f"qm set {self.vm_id} -balloon {ram}", mutating=True)
                 self.logger.info(f"RAM balloon set to {ram} MB for VM {self.vm_id} (hotplug applied).")
             elif is_running and memory_hotplug and not numa_enabled:
                 # Hotplug enabled but NUMA not - this won't work properly
@@ -446,9 +483,7 @@ class VMResourceManager:
                     f"VM {self.vm_id} has memory hotplug enabled but NUMA is disabled. "
                     "Memory changes will require a reboot. Enable NUMA for live memory scaling."
                 )
-                command = f"qm set {self.vm_id} -memory {ram}"
-                output = self.ssh_client.execute_command(command)
-                self._get_command_output(output)
+                self._run(f"qm set {self.vm_id} -memory {ram}", mutating=True)
                 self.logger.info(f"RAM config set to {ram} MB for VM {self.vm_id} (requires reboot).")
             elif is_running:
                 # No hotplug - warn and set config only
@@ -456,15 +491,11 @@ class VMResourceManager:
                     f"VM {self.vm_id} does not have memory hotplug enabled. "
                     "Memory changes will require a reboot. Enable 'hotplug: memory' and NUMA for live scaling."
                 )
-                command = f"qm set {self.vm_id} -memory {ram}"
-                output = self.ssh_client.execute_command(command)
-                self._get_command_output(output)
+                self._run(f"qm set {self.vm_id} -memory {ram}", mutating=True)
                 self.logger.info(f"RAM config set to {ram} MB for VM {self.vm_id} (requires reboot).")
             else:
                 # VM not running - just set memory config
-                command = f"qm set {self.vm_id} -memory {ram}"
-                output = self.ssh_client.execute_command(command)
-                self._get_command_output(output)
+                self._run(f"qm set {self.vm_id} -memory {ram}", mutating=True)
                 self.logger.info(f"RAM set to {ram} MB for VM {self.vm_id}.")
         except Exception as e:
             self.logger.error(f"Failed to set RAM to {ram}: {e}")
@@ -549,9 +580,7 @@ class VMResourceManager:
     def _set_cores(self, cores):
         """Set the CPU cores for the VM (config change, requires reboot for running VMs)."""
         try:
-            command = f"qm set {self.vm_id} -cores {cores}"
-            output = self.ssh_client.execute_command(command)
-            self._get_command_output(output)
+            self._run(f"qm set {self.vm_id} -cores {cores}", mutating=True)
             self.logger.debug(f"CPU cores config set to {cores} for VM {self.vm_id}.")
         except Exception as e:
             self.logger.error(f"Failed to set CPU cores to {cores}: {e}")
@@ -560,9 +589,7 @@ class VMResourceManager:
     def _set_vcpus(self, vcpus):
         """Set the vCPUs for the VM (can be hotplugged if enabled)."""
         try:
-            command = f"qm set {self.vm_id} -vcpus {vcpus}"
-            output = self.ssh_client.execute_command(command)
-            self._get_command_output(output)
+            self._run(f"qm set {self.vm_id} -vcpus {vcpus}", mutating=True)
             self.logger.debug(f"vCPUs set to {vcpus} for VM {self.vm_id}.")
         except Exception as e:
             self.logger.error(f"Failed to set vCPUs to {vcpus}: {e}")


### PR DESCRIPTION
The last four items on the [known limitations](https://fabriziosalmi.github.io/proxmox-vm-autoscale/reference/limitations.html) page, in the order they depend on each other.

## 1. A failed `qm set` was reported as a success

`execute_command` returns the exit status rather than raising, and **every caller discarded it**. Demonstrated against `main` with a `qm set` that exits 25:

```
main:
  WARNING VM 101: Increased cores to 5 (requires reboot for full effect)
                  and vCPUs to 5 (hotplug applied).
  => scale_cpu returned True   (qm set had exited 25)
  => cooldown consumed: True

this branch:
  => raised CommandFailed: `qm set 101 -cores 5` failed on VM 101 with
     exit status 25: unable to modify: storage busy
  => cooldown consumed: False
```

So it was not only a wrong log line: the success path sent a notification, wrote a billing record, and **burned the cooldown**, delaying the retry by a full `scale_cooldown`.

## 2. A failed `qm config` read invented a plausible number

Worse, because it was silent. The getters returned `1` core, `1` vCPU or `512` MB when the command failed, and that fiction went straight into a scaling decision — the service would cheerfully "scale up from 1 core" a guest that actually had eight.

They now raise. An **absent** key still means the documented Proxmox default, because that is what absence legitimately means there.

Also: `qm status` exiting non-zero was treated as transient and retried three times with backoff. A VM that does not exist is not a transient fault; it now fails fast and logs stderr instead of costing 30 seconds.

## 3. Dry-run mode

```yaml
dry_run: true
```

```
[WARNING] DRY RUN: no command that changes a VM will be issued.
[INFO]    VM 101 current usage - CPU: 91.20%, RAM: 44.10%
[INFO]    [dry-run] VM 101: would run `qm set 101 -vcpus 3`
```

It sits at the **command layer**, so every write path is covered — hotplug auto-configuration included, which a check in the scaling functions alone would have missed.

Reads still happen and the cooldown still applies, so what you get is a real evaluation against real usage at the real cadence, not a sketch. Notifications carry `[DRY RUN]`; billing records nothing, since nothing changed.

## 4. Per-VM `scaling_limits`

Thresholds became per-VM in v1.5.0 but limits stayed global, so one instance still could not manage a 2-core web server and a 16-core database.

```yaml
virtual_machines:
  - vm_id: 102
    scaling_limits:
      max_cores: 16
      max_ram_mb: 32768
```

Resolved most-specific first: the VM's own block → the global section → the legacy flat keys → the built-in default.

## 5. Prometheus metrics

```yaml
metrics:
  enabled: true
  bind: 127.0.0.1      # default
  port: 9808
```

**Off by default and localhost-bound when on.** This process holds root credentials, the series name your nodes and VMIDs, and there is no authentication — defaulting to `0.0.0.0` would have been indefensible. A bind failure is logged and the service carries on; a metrics endpoint is not worth taking the autoscaler down for.

Standard library only. A client library is not worth a dependency for one endpoint on a service whose install story is three apt packages.

Sixteen series: cycle count and duration, per-VM CPU/RAM, running state and errors, scaling actions by resource and direction, scaling failures, per-node utilisation, gate blocks.

> A metric that could not be read has its series **removed**, not set to zero. Emitting a zero would put the same lie into your dashboards that v1.4.0 removed from the scaling decision. Watch `vm_autoscale_metric_unavailable_total` instead.

The [operations guide](https://fabriziosalmi.github.io/proxmox-vm-autoscale/guide/operations.html#metrics) has the full table and four alerting rules worth having.

## Verification

- **201 tests**, 31 new. The metrics tests start a real server and make real HTTP requests rather than mocking the transport.
- The command-failure behaviour is demonstrated above by running the same probe against both trees.
- Concurrency on the registry is tested with four threads and 2000 increments.

## Compatibility

No config changes required; all three new keys default to the previous behaviour. One thing to know: **a scaling action that fails now raises instead of being logged as done.** If something in your fleet has been silently failing to scale, you will start seeing `CommandFailed` in the log. That is the point, but it will look like new breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)